### PR TITLE
Revamp README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Extended Tuya integration for Home Assistant.
 
 ## Purpose
 
-This custom integration is there to add the missing entities for [Tuya's official integration](https://www.home-assistant.io/integrations/tuya/).
+This custom integration is there to add the missing entities for the [official Tuya integration](https://www.home-assistant.io/integrations/tuya/).
 
 The reason why this is not merged in the official Tuya integration is that the way this is done is not officially supported by Home Assistant (i.e. this integration is using _hacks_ to do its job).
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,29 @@ This custom integration is there to add the missing entities for [Tuya's officia
 
 The reason why this is not merged in the official Tuya integration is that the way this is done is not officially supported by Home Assistant (i.e. this integration is using _hacks_ to do its job).
 
+### Comparison
+
+The following table compares the features of this integration with the official one, as well as the different modes this integration supports.
+
+Legend:
+
+- _OT_: Official Tuya integration
+- _OT+XT_: Xtend Tuya **without Tuya cloud credentials** but **alongside the official Tuya integration**
+- _OT+XT+Cloud_: Xtend Tuya **with Tuya cloud credentials** but **alongside the official Tuya integration**
+- _XT_: Xtend Tuya **without Tuya cloud credentials** and **without the official Tuya integration**
+- _XT+Cloud_: Xtend Tuya **with Tuya cloud credentials** and **without the official Tuya integration**
+
+| Functionality                   |         OT         |       OT+XT        |    OT+XT+Cloud     |         XT         |      XT+Cloud      | Remarks                                                                 |
+| :------------------------------ | :----------------: | :----------------: | :----------------: | :----------------: | :----------------: | :---------------------------------------------------------------------- |
+| Regular Tuya entities           | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                                                                         |
+| Additional supported entities   |        :x:         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                                                                         |
+| All possible supported entities |        :x:         |        :x:         |        :x:         |        :x:         | :white_check_mark: | _OT+XT+Cloud_ is close but in some rare cases entitites will be missing |
+| Autocorrection of some entities |        :x:         |        :x:         |        :x:         |        :x:         | :white_check_mark: | _XT+Cloud_ uses multiple source to determine the entity props           |
+| Multiple account support        |        :x:         | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | Only for multiple accounts in _XT_, not the official Tuya integration   |
+| Shared device support           |        :x:         |        :x:         | :white_check_mark: |        :x:         | :white_check_mark: |                                                                         |
+| Shared home support             | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |                                                                         |
+| Localized entity names          | :white_check_mark: |        :x:         |        :x:         |        :x:         |        :x:         | Due to a limitation with custom components                              |
+
 ## Installation
 
 Easiest install is via [HACS](https://hacs.xyz/):
@@ -26,27 +49,4 @@ If you have more than one Tuya account, go to the Xtend Tuya integration page (_
 
 ### Adding your Tuya Cloud credentials
 
-If after adding this integration you still have entities which are missing, you can try inserting your Tuya Cloud credentials. The full procedure is described [here](./docs/cloud_credentials.md).
-
-### Supported operation modes
-
-This integration supports different operating modes:
-
-- Regular Tuya integration (RT) (without XT or the cloud)
-- Standalone without cloud credentials (ST) (use XT instead of the regular Tuya integration)
-- Standalone with cloud credentials (ST+Cloud)
-- Alongside Tuya without cloud credentials (TU) (use XT alongside the regular Tuya integration)
-- Alongside Tuya with cloud credentials (TU+Cloud)
-
-The table below shows the different functionalities of each operating mode:
-
-| Functionnality                  | RT  | ST  | ST+Cloud | TU  | TU+Cloud | Remarks                                                            |
-| :------------------------------ | :-: | :-: | :------: | :-: | :------: | :----------------------------------------------------------------- |
-| Regular Tuya entities           |  X  |  X  |    X     |  X  |    X     |                                                                    |
-| Additional supported entities   |     |  X  |    X     |  X  |    X     |                                                                    |
-| All possible supported entities |     |     |    X     |     |          | TU+Cloud is close but in some rare cases entitites will be missing |
-| Autocorrection of some entities |     |     |    X     |     |          | ST+Cloud uses multiple source to determine the entity props        |
-| Multiple account support        |     |  X  |    X     |  X  |    X     | Only for multiple accounts in XT, not the regular Tuya integration |
-| Shared device support           |     |     |    X     |     |    X     |                                                                    |
-| Shared home support             |  X  |  X  |    X     |  X  |    X     |                                                                    |
-| Localized entity names          |  X  |     |          |     |          | Due to a limitation with custom components                         |
+If after adding this integration you still have entities which are missing, you can try inserting your Tuya Cloud credentials (_XT+Cloud_ in the table above). The full procedure is described [here](./docs/cloud_credentials.md).

--- a/README.md
+++ b/README.md
@@ -1,51 +1,52 @@
-# xtend_tuya
-HomeAssistant eXtend Tuya's integration
+# Xtend Tuya
 
-# Current status
-The custom component is working as expected
+Extended Tuya integration for Home Assistant.
 
-# Purpose
-This Custom Integration is there to add the missing entities in Tuya's integration.<br/>
-The reason why this is not merged in the main Tuya integration is that the way this is done is not officially supported by HomeAssistant (AKA this integration is using hacks to do its job)
+## Purpose
 
-# Supported operation modes
-This integration supports different operating modes:<br/>
-- Regular Tuya integration (RT) (without XT or the cloud)<br/>
-- Standalone without cloud credentials (ST) (use XT instead of the regular Tuya integration)<br/>
-- Standalone with cloud credentials (ST+Cloud)<br/>
-- Alongside Tuya without cloud credentials(TU) (use XT alongside the regular Tuya integration)<br/>
-- Alongside Tuya with cloud credentials(TU+Cloud)<br/>
-<br/>
-The table below shows the different functionnalities of each operating mode<br/>
+This custom integration is there to add the missing entities for [Tuya's official integration](https://www.home-assistant.io/integrations/tuya/).
+
+The reason why this is not merged in the official Tuya integration is that the way this is done is not officially supported by Home Assistant (i.e. this integration is using _hacks_ to do its job).
+
+## Installation
+
+Easiest install is via [HACS](https://hacs.xyz/):
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=azerty9971&repository=xtend_tuya&category=integration)
+
+1. Click the button above, and install this integration via HACS.
+2. Restart Home Assistant.
+3. Go to _Settings_ -> _Devices and integrations_ -> _Add integration_ and select **Xtend Tuya**.
+
+## Usage
+
+Once installed, the devices provided by the official Tuya integration should now have the new entities automatically added and they should be supported in the Energy dashboard for instance.
+
+If you have more than one Tuya account, go to the Xtend Tuya integration page (_Settings_ -> _Devices and integrations_ -> _Xtend Tuya_) and click _Add a bridge_. This will pull the next available Tuya account automatically (you can repeat for more).
+
+### Adding your Tuya Cloud credentials
+
+If after adding this integration you still have entities which are missing, you can try inserting your Tuya Cloud credentials. The full procedure is described [here](./docs/cloud_credentials.md).
+
+### Supported operation modes
+
+This integration supports different operating modes:
+
+- Regular Tuya integration (RT) (without XT or the cloud)
+- Standalone without cloud credentials (ST) (use XT instead of the regular Tuya integration)
+- Standalone with cloud credentials (ST+Cloud)
+- Alongside Tuya without cloud credentials (TU) (use XT alongside the regular Tuya integration)
+- Alongside Tuya with cloud credentials (TU+Cloud)
+
+The table below shows the different functionalities of each operating mode:
 
 | Functionnality                  | RT  | ST  | ST+Cloud | TU  | TU+Cloud | Remarks                                                            |
 | :------------------------------ | :-: | :-: | :------: | :-: | :------: | :----------------------------------------------------------------- |
-| Regular Tuya entities           | X   | X   | X        | X   | X        |                                                                    |
-| Additional supported entities   |     | X   | X        | X   | X        |                                                                    |
-| All possible supported entities |     |     | X        |     |          | TU+Cloud is close but in some rare cases entitites will be missing |
-| Autocorrection of some entities |     |     | X        |     |          | ST + Cloud uses multiple source to determine the entity props      |
-| Multiple account support        |     | X   | X        | X   | X        | Only for multiple accounts in XT, not the regular Tuya integration |
-| Shared device support           |     |     | X        |     | X        |                                                                    |
-| Shared home support             | X   | X   | X        | X   | X        |                                                                    |
-| Localized entity names          | X   |     |          |     |          | Due to a limitation with custom components                         |
-
-
-# Installation
-You have 2 choices to install, either via Home Assistant Community Store (HACS) or using manual install:<br/>
-1- HACS (recommended)<br/>
-Add the current repository URL to your HACS repositories by going into HACS, click the 3 dots, add custom repository.<br/>
-In the screen, fill azerty9971/xtend_tuya as the repository, select integration as type and click add.<br/>
-Now you can download xtend_tuya directly from HACS (and get notified when I update it)<br/>
-<br/>
-2- Manual installation (advanced)<br/>
-Clone the repository and put all the files using SSH to your /homeassistant/custom_components folder (final folder will look like: /homeassistant/custom_components/xtend_tuya)<br/>
-Once this is done, restart your HomeAssistant instance, go to Settings -> Devices and integrations -> Add integration -> type "Tuya" and select Xtended Tuya<br/>
-
-# Usage
-Once installed, the base devices should have the new entities automatically added and they should be supported in the Energy dashboard for instance<br/>
-If you have more than 1 tuya account, click go to the Xtended Tuya configuration page (Settings -> Devices and integrations -> Xtended Tuya) and click "Add a bridge", this will pull the next available Tuya configuration available (repeat for more)
-
-# Adding your Tuya Cloud credentials
-If you have missing entities, you can try inserting your Tuya Cloud API credentials.<br/>
-The full procedure is described here: https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
-
+| Regular Tuya entities           |  X  |  X  |    X     |  X  |    X     |                                                                    |
+| Additional supported entities   |     |  X  |    X     |  X  |    X     |                                                                    |
+| All possible supported entities |     |     |    X     |     |          | TU+Cloud is close but in some rare cases entitites will be missing |
+| Autocorrection of some entities |     |     |    X     |     |          | ST+Cloud uses multiple source to determine the entity props        |
+| Multiple account support        |     |  X  |    X     |  X  |    X     | Only for multiple accounts in XT, not the regular Tuya integration |
+| Shared device support           |     |     |    X     |     |    X     |                                                                    |
+| Shared home support             |  X  |  X  |    X     |  X  |    X     |                                                                    |
+| Localized entity names          |  X  |     |          |     |          | Due to a limitation with custom components                         |

--- a/custom_components/xtend_tuya/manifest.json
+++ b/custom_components/xtend_tuya/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "xtend_tuya",
-  "name": "Xtended Tuya",
+  "name": "Xtend Tuya",
   "after_dependencies": ["tuya"],
   "codeowners": ["@azerty9971"],
   "config_flow": true,

--- a/docs/cloud_credentials.md
+++ b/docs/cloud_credentials.md
@@ -1,5 +1,5 @@
 # Purpose
-The purpose of this documentation is to be able to configure the Tuya IOT Platform cloud credentials in eXtended Tuya (XT)
+The purpose of this documentation is to be able to configure the Tuya IOT Platform cloud credentials in Xtend Tuya.
 
 # READ THIS CAREFULLY
 Some initial configurations have to be done right the first time, this is because they are a pain to update afterward if you got them wrong.<br/>
@@ -57,7 +57,7 @@ DO NOT USE THE WESTERN EUROPE OR EASTERN AMERICA DATA CENTERS, THEY ARE RESERVED
 ![image](https://github.com/user-attachments/assets/57ac6999-742b-4622-9ad2-7a9670ebd1f7)<br/>
 5.2- Go to "Device & services"<br/>
 ![image](https://github.com/user-attachments/assets/aa3a20aa-ae0a-4341-9d9a-4ffed4e0c7a1)<br/>
-5.3- Click on "Xtended Tuya"<br/>
+5.3- Click on "Xtend Tuya"<br/>
 ![image](https://github.com/user-attachments/assets/462d302a-7154-4fc3-ada9-e766aa0b5d4b)<br/>
 5.4- Click on the "Configure" button next to the account you want to configure<br/>
 ![image](https://github.com/user-attachments/assets/be1e0eec-3743-4f7c-8497-eabbd2992fcb)<br/>

--- a/docs/configure_locks.md
+++ b/docs/configure_locks.md
@@ -15,4 +15,4 @@ https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
 ![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)<br/>
 5- Verify that the "Smart Lock Open Service" is activated:<br/>
 ![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)<br/>
-6- You should now be able to open/close your locks using eXtended Tuya (XT)<br/>
+6- You should now be able to open/close your locks using Xtend Tuya<br/>

--- a/docs/enable_webrtc.md
+++ b/docs/enable_webrtc.md
@@ -15,4 +15,3 @@ https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
 ![image](https://github.com/user-attachments/assets/61ffbae2-6978-42a9-a396-41a9bc5818f8)<br/>
 5- Verify that the "IoT Video Live Stream" is activated:<br/>
 ![image](https://github.com/user-attachments/assets/cd58e04d-632d-4e32-8d17-b5447480cb92)<br/>
-6- You should now be able to open/close your locks using eXtended Tuya (XT)<br/>


### PR DESCRIPTION
For the first time ever, I was able to control my Tuya locks from within Home Assistant.

I wanted to contribute back somehow, and I noticed the README could use some improvements.

I have also ensured the integration is called _Xtend Tuya_ everywhere, for consistency.

I also formatted `README.md` with prettier.

If you like it, I can send an additional PR reviewing the other documents.