### PR TITLE
Add entity for set_temp_1 DP code, required by Setti+ KT970K Smart Kettle

### DIFF
--- a/custom_components/xtend_tuya/const.py
+++ b/custom_components/xtend_tuya/const.py
@@ -532,6 +532,7 @@ class DPCode(StrEnum):
     TEMP_CURRENT_F = "temp_current_f"  # Current temperature in °F
     TEMP_INDOOR = "temp_indoor"  # Indoor temperature in °C
     TEMP_SET = "temp_set"  # Set the temperature in °C
+    TEMP_SET_1 = "temp_set_1"  # Set the warm temperature in °C
     TEMP_SET_F = "temp_set_f"  # Set the temperature in °F
     TEMP_UNIT_CONVERT = "temp_unit_convert"  # Temperature unit switching
     TEMP_VALUE = "temp_value"  # Color temperature

--- a/custom_components/xtend_tuya/number.py
+++ b/custom_components/xtend_tuya/number.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.number import (
+    NumberDeviceClass,
     NumberEntity,
     NumberEntityDescription,
 )
@@ -71,6 +72,14 @@ COUNTDOWNS: tuple[NumberEntityDescription, ...] = (
 # default instructions set of each category end up being a number.
 # https://developer.tuya.com/en/docs/iot/standarddescription?id=K9i5ql6waswzq
 NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
+    "bh": (
+        NumberEntityDescription(
+            key=DPCode.TEMP_SET_1,
+            translation_key="warm_temperature",
+            device_class=NumberDeviceClass.TEMPERATURE,
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
     "dbl": (
         NumberEntityDescription(
             key=DPCode.VOLUME_SET,

--- a/custom_components/xtend_tuya/strings.json
+++ b/custom_components/xtend_tuya/strings.json
@@ -405,6 +405,9 @@
       "time": {
         "name": "Time"
       },
+      "warm_temperature": {
+        "name": "Warm temperature"
+      },
       "temperature_after_boiling": {
         "name": "Temperature after boiling"
       },

--- a/custom_components/xtend_tuya/translations/en.json
+++ b/custom_components/xtend_tuya/translations/en.json
@@ -408,6 +408,9 @@
       "time": {
         "name": "Time"
       },
+      "warm_temperature": {
+        "name": "Warm temperature"
+      },
       "temperature_after_boiling": {
         "name": "Temperature after boiling"
       },

--- a/custom_components/xtend_tuya/translations/pl.json
+++ b/custom_components/xtend_tuya/translations/pl.json
@@ -58,7 +58,16 @@
             },
             "time": {
                 "name": "Czas"
-            }
+            },
+            "warm_temperature": {
+                "name": "Utrzymywana temperatura"
+              },
+              "temperature_after_boiling": {
+                "name": "Temperatura po zagotowaniu"
+              },
+              "heat_preservation_time": {
+                "name": "Czas podtrzymania ciep\u0142a"
+              }
         },
         "select": {
             "basic_anti_flicker": {


### PR DESCRIPTION
I have Setti+ KT970K Smart Kettle. In order to be able to heat up to selected temperature, like in Tuya app, one need to send the command with DP code `temp_set_1` (which Tuya reports as _warm time_). Neither official Tuya integration nor xtend_Tuya does not create entity for it. With this PR such an entity is created. Please merge it, as it is necessary to use the full potential of this kettle.