### PR TITLE
Improve power consumption sensor compatiblity

### DIFF
--- a/custom_components/xtend_tuya/const.py
+++ b/custom_components/xtend_tuya/const.py
@@ -141,6 +141,15 @@ class XTDPCode(StrEnum):
 
     https://developer.tuya.com/en/docs/iot/standarddescription?id=K9i5ql6waswzq
     """
+    POWER_A = "power_a"
+    POWER_B = "power_b"
+    DIRECTION_A="direction_a"
+    DIRECTION_B="direction_b"
+    VOLTAGE_A="voltage_a"
+    CURRENT_A="current_a"
+    CURRENT_B="current_b"
+    POWER_FACTOR="power_factor"
+    POWER_FACTOR_B="power_factor_b"
     ACHZ = "ACHZ"
     ACI = "ACI"
     ACTIVEPOWER = "ActivePower"

--- a/custom_components/xtend_tuya/sensor.py
+++ b/custom_components/xtend_tuya/sensor.py
@@ -489,6 +489,44 @@ HUMIDITY_SENSORS: tuple[XTSensorEntityDescription, ...] = (
 
 ELECTRICITY_SENSORS: tuple[XTSensorEntityDescription, ...] = (
     XTSensorEntityDescription(
+        key=XTDPCode.POWER_A,
+        translation_key="power_a",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    XTSensorEntityDescription(
+        key=XTDPCode.POWER_B,
+        translation_key="power_b",
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+    ),
+    XTSensorEntityDescription(
+        key=XTDPCode.CURRENT_A,
+        translation_key="current_a",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CURRENT,
+    ),
+    XTSensorEntityDescription(
+        key=XTDPCode.CURRENT_B,
+        translation_key="current_b",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.CURRENT,
+    ),
+    XTSensorEntityDescription(
+        key=XTDPCode.VOLTAGE_A,
+        translation_key="voltage_a",
+        state_class=SensorStateClass.MEASUREMENT,
+        device_class=SensorDeviceClass.VOLTAGE,
+    ),
+    XTSensorEntityDescription(
+        key=XTDPCode.DIRECTION_A,
+        translation_key="direction_a",
+    ),
+    XTSensorEntityDescription(
+        key=XTDPCode.DIRECTION_B,
+        translation_key="direction_b",
+    ),
+    XTSensorEntityDescription(
         key=XTDPCode.ACHZ,
         translation_key="achz",
         state_class=SensorStateClass.MEASUREMENT,

--- a/custom_components/xtend_tuya/translations/fr.json
+++ b/custom_components/xtend_tuya/translations/fr.json
@@ -456,6 +456,33 @@
             }
         },
         "sensor": {
+            "power_a":{
+                "name": "Puissance voie A"
+            },
+            "power_b":{
+                "name": "Puissance voie B"
+            },
+            "direction_a":{
+                "name": "Direction puissance voie A"
+            },
+            "direction_b":{
+                "name": "Direction puissance voie A B"
+            },  
+            "VOLTAGE_A": {
+                "name": "Tension"
+            },
+            "current_a": {
+                "name": "Courant voie A"
+            },
+            "current_b": {
+                "name": "Courant voie B"
+            },
+            "power_factor": {
+                "name": "Facteur de puissance voie A"
+            },
+            "power_factor_b": {
+                "name": "Facteur de puissance voie B"
+            },
             "air_quality": {
                 "name": "Qualit\u00e9 de l'air",
                 "state": {


### PR DESCRIPTION
I added those changes in local to test and to improve the compatibility with my ZNDB power consumption sensor.
As it is generic, I added it to the electricity sensor.
Therefor, I can get the data about the 2 channels and also the direction (do I import or import electricity)