### PR TITLE
Optimize startup by running cleanup tasks in the background

### DIFF
--- a/custom_components/xtend_tuya/__init__.py
+++ b/custom_components/xtend_tuya/__init__.py
@@ -57,7 +57,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: XTConfigEntry) -> bool:
     )
 
     # Cleanup device registry
-    await cleanup_device_registry(hass, multi_manager, entry)
+    hass.async_create_task(cleanup_device_registry(hass, multi_manager, entry))
 
     # Register known device IDs
     device_registry = dr.async_get(hass)
@@ -91,7 +91,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: XTConfigEntry) -> bool:
     # So the subscription is here
     await hass.async_add_executor_job(multi_manager.refresh_mq)
     service_manager.register_services()
-    await cleanup_duplicated_devices(hass, entry)
+    hass.async_create_task(cleanup_duplicated_devices(hass, entry))
     await multi_manager.on_loading_finalized(hass, entry)
     LOGGER.debug(f"Xtended Tuya {entry.title} loaded in {datetime.now() - start_time}")
     return True


### PR DESCRIPTION
Refactor device cleanup to be non-blocking.

The `cleanup_device_registry` and `cleanup_duplicated_devices` functions can be slow, especially on systems with many devices. By running them as background tasks instead of awaiting them during `async_setup_entry`, the integration can finish its setup process much faster, improving the user's experience during Home Assistant startup.

This change converts the `await` calls for these functions to `hass.async_create_task` to make them non-blocking.