### PR TITLE
Fix custom is_on function call for binary sensors

### DIFF
--- a/custom_components/xtend_tuya/binary_sensor.py
+++ b/custom_components/xtend_tuya/binary_sensor.py
@@ -182,7 +182,7 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: x != 0,
+            is_on=lambda x: None if x is None else x != 0,
         ),
         XTBinarySensorEntityDescription(
             key=f"{XTDPCode.MALFUNCTION}_0",
@@ -190,7 +190,7 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error_flow_meter",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: (x >> 0) & 1,
+            is_on=lambda x: None if x is None else (x >> 0) & 1,
         ),
         XTBinarySensorEntityDescription(
             key=f"{XTDPCode.MALFUNCTION}_1",
@@ -198,7 +198,7 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error_valve_low_battery",
             device_class=BinarySensorDeviceClass.BATTERY,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: (x >> 1) & 1,
+            is_on=lambda x: None if x is None else (x >> 1) & 1,
         ),
         XTBinarySensorEntityDescription(
             key=f"{XTDPCode.MALFUNCTION}_2",
@@ -206,7 +206,7 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error_sensor_low_battery",
             device_class=BinarySensorDeviceClass.BATTERY,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: (x >> 2) & 1,
+            is_on=lambda x: None if x is None else (x >> 2) & 1,
         ),
         XTBinarySensorEntityDescription(
             key=f"{XTDPCode.MALFUNCTION}_3",
@@ -214,7 +214,7 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error_sensor_offline",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: (x >> 3) & 1,
+            is_on=lambda x: None if x is None else (x >> 3) & 1,
         ),
         XTBinarySensorEntityDescription(
             key=f"{XTDPCode.MALFUNCTION}_4",
@@ -222,7 +222,7 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error_water_shortage",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: (x >> 4) & 1,
+            is_on=lambda x: None if x is None else (x >> 4) & 1,
         ),
         XTBinarySensorEntityDescription(
             key=f"{XTDPCode.MALFUNCTION}_5",
@@ -230,14 +230,14 @@ BINARY_SENSORS: dict[str, tuple[XTBinarySensorEntityDescription, ...]] = {
             translation_key="error_other",
             device_class=BinarySensorDeviceClass.PROBLEM,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: (x >> 5) & 1,
+            is_on=lambda x: None if x is None else (x >> 5) & 1,
         ),
         XTBinarySensorEntityDescription(
             key=XTDPCode.VBAT_STATE,
             translation_key="battery_charging",
             device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
             entity_category=EntityCategory.DIAGNOSTIC,
-            is_on=lambda x: x > 127,
+            is_on=lambda x: None if x is None else x > 127,
         ),
     ),
     "smd": (


### PR DESCRIPTION
Fix call to custom is_on function for binary sensors, which was broken due to upstream changes in Tuya code