### PR TITLE
implements hvac_action based on work_state dp

### DIFF
--- a/custom_components/xtend_tuya/const.py
+++ b/custom_components/xtend_tuya/const.py
@@ -716,6 +716,7 @@ class XTDPCode(StrEnum):
     COLOR = "Color"
     CONNECTION_STATE = "connection_state"
     CONTROL_SKIP = "control_skip"
+    COLD_HOT_SELECT = "cold_hot_select"  # DP 109
     CTIME = "Ctime"
     CTIME2 = "CTime2"
     CURRENT = "Current"


### PR DESCRIPTION
This PR introduces the support for hvac_action (current working state) in the climate platform. Previously, the integration only showed the hvac_mode (target state), making it impossible to know if the device was actively heating/cooling or idle (e.g., thermostat reached temperature but remains in "heat" mode).

🚀 Changes
DPCode Expansion: Added WORK_STATE, WORK_STATUS, and WORK_STAT to XT_CLIMATE_ACTION_DPCODES to cover different Tuya implementations (including DP 19).

Dynamic Action Detection: Implemented the hvac_action property in XTClimateEntity.

Status Mapping: Added a normalization logic to map Tuya string statuses to Home Assistant constants:

heating, warming, opened → HVACAction.HEATING

cooling → HVACAction.COOLING

idle, standby, closed → HVACAction.IDLE

Wrapper Integration: Updated the entity factory to look for and inject the action_wrapper during device discovery.

🛠 Technical Details
The implementation uses a TuyaDPCodeEnumWrapper to monitor the Data Points responsible for the device's running state. This allows the UI to correctly display the "Heating" (orange) or "Idle" (anthracite) status on the climate cards.

🧪 Testing performed
[x] Verified with a "wk" (thermostat) device.

[x] Checked that the attribute hvac_action updates correctly when the relay clicks on/off.

[x] Verified that no regressions occur if the work_state DP is missing (falls back to default behavior).


This PR introduces the correct handling of switching between heating and cooling modes for Climate devices (heat pumps/air conditioners) that use the specific cold_hot_select DP Code instead of the traditional work_mode.

🛠️ Changes
HVAC Mode Interception: Modified the async_set_hvac_mode method to explicitly handle calls to HVACMode.HEAT and HVACMode.COOL.

MultiManager Integration: Implemented command sending via the centralized dispatcher device_manager.send_commands. This resolves the AttributeError: '_send_command' error caused by the absence of the native Tuya method in the XTClimateEntity base class.

DP Code 109 Mapping: Added logic to map Home Assistant constants to the Enum values ​​required by the device:

HVACMode.HEAT -> "hot"

HVACMode.COOL -> "cold"

Thread-Safe Execution: Used async_add_executor_job to handle synchronized calls to the manager without blocking the Home Assistant event loop.
