### PR TITLE
IPv6 timeout hang fix

### DIFF
--- a/custom_components/xtend_tuya/__init__.py
+++ b/custom_components/xtend_tuya/__init__.py
@@ -1,5 +1,22 @@
 """Support for Tuya Smart devices."""
 
+import socket
+
+# save the original DNS lookup function
+_original_getaddrinfo = socket.getaddrinfo
+
+def _getaddrinfo_ipv4_only(host, port, family=0, type=0, proto=0, flags=0):
+    """
+    IPv6 sniper: If the request is going to a tuya server, 
+    force it to use IPv4 (AF_INET) to prevent IPv6 timeout
+    """
+    if host and ("tuya" in host or "tinytuya" in host):
+        return _original_getaddrinfo(host, port, socket.AF_INET, type, proto, flags)
+    return _original_getaddrinfo(host, port, family, type, proto, flags)
+
+# Replace the global function with the sniper
+socket.getaddrinfo = _getaddrinfo_ipv4_only
+
 from __future__ import annotations
 import logging
 import asyncio


### PR DESCRIPTION
This should force any connections to a host with `tuya` in the name to use IPv4 instead of IPv6; consider this a starting point because I don't know the codebase front to back. 