### PR TITLE
Update air quality translation for 'great' state

### DIFF
--- a/custom_components/xtend_tuya/translations/zh-Hans.json
+++ b/custom_components/xtend_tuya/translations/zh-Hans.json
@@ -559,7 +559,7 @@
                 "name": "\u7a7a\u6c14\u8d28\u91cf",
                 "state": {
                     "good": "\u826f\u597d",
-                    "great": "\u4f1f\u5927",
+                    "great": "\u6781\u4f73",
                     "mild": "\u8f7b\u5fae",
                     "severe": "\u4e25\u91cd"
                 }


### PR DESCRIPTION
Update air quality translation for 'great' state
great的中文翻译应该为“极佳”而不是“伟大”