### PR TITLE
Fix XTButtonEntity and sensor definition

### DIFF
--- a/custom_components/xtend_tuya/button.py
+++ b/custom_components/xtend_tuya/button.py
@@ -665,7 +665,7 @@ class XTButtonEntity(XTEntity, TuyaButtonEntity):
                 definition=definition,
             )
         return XTButtonEntity(
-            device == device,
+            device=device,
             device_manager=device_manager,
             description=XTButtonEntityDescription(**description.__dict__),
             definition=definition,

--- a/custom_components/xtend_tuya/sensor.py
+++ b/custom_components/xtend_tuya/sensor.py
@@ -1676,7 +1676,6 @@ SENSORS: dict[str, tuple[XTSensorEntityDescription, ...]] = {
         XTSensorEntityDescription(
             key=XTDPCode.STATUS,
             translation_key="cat_litter_box_status",
-            state_class=SensorStateClass.MEASUREMENT,
             entity_category=EntityCategory.DIAGNOSTIC,
             entity_registry_enabled_default=True,
         ),


### PR DESCRIPTION
When the system started up, two error messages appeared in the log:
---
XTButtonEntity
```
Error while setting up xtend_tuya platform for button: 'bool' object has no attribute 'id'
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 455, in _async_setup_platform
    await asyncio.shield(awaitable)
  File "/config/custom_components/xtend_tuya/button.py", line 613, in async_setup_entry
    async_discover_device([*hass_data.manager.device_map])
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/xtend_tuya/button.py", line 507, in async_discover_device
    entities.extend(
    ~~~~~~~~~~~~~~~^
        XTButtonEntity.get_entity_instance(
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<20 lines>...
        )
        ^
    )
    ^
  File "/config/custom_components/xtend_tuya/button.py", line 508, in <genexpr>
    XTButtonEntity.get_entity_instance(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        device=device,
        ^^^^^^^^^^^^^^
    ...<2 lines>...
        definition=definition,
        ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/config/custom_components/xtend_tuya/button.py", line 667, in get_entity_instance
    return XTButtonEntity(
        device == device,
    ...<2 lines>...
        definition=definition,
    )
  File "/config/custom_components/xtend_tuya/button.py", line 640, in __init__
    super(XTEntity, self).__init__(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        device=device,
        ^^^^^^^^^^^^^^
    ...<2 lines>...
        definition=definition,
        ^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/usr/src/homeassistant/homeassistant/components/tuya/button.py", line 112, in __init__
    super().__init__(device, device_manager, description)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/tuya/entity.py", line 30, in __init__
    self._attr_unique_id = f"tuya.{device.id}"
                                   ^^^^^^^^^
AttributeError: 'bool' object has no attribute 'id'
```
---
sensor definition
```
Error adding entity sensor.cat_litter_box_status for domain sensor with platform xtend_tuya
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 684, in state
    numerical_value = int(value)
ValueError: invalid literal for int() with base 10: 'standby'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 687, in state
    numerical_value = float(value)
ValueError: could not convert string to float: 'standby'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 680, in _async_add_entities
    await self._async_add_entity(
        entity, False, entity_registry, config_subentry_id
    )
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 998, in _async_add_entity
    await entity.add_to_platform_finish()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1431, in add_to_platform_finish
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1050, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1199, in _async_write_ha_state
    ) = self.__async_calculate_state()
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1106, in __async_calculate_state
    state = self._stringify_state(available)
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1056, in _stringify_state
    if (state := self.state) is None:
                 ^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 691, in state
    raise ValueError(
    ...<5 lines>...
    ) from err
ValueError: Sensor sensor.kotiachii_gorshok_status has device class 'None', state class 'measurement' unit 'None' and suggested precision 'None' thus indicating it has a numeric value; however, it has the non-numeric value: 'standby' (<class 'str'>)
```