### PR TITLE
add hum_calibration to DPCODE_PREFERED_DEVICE_CLASS

### DIFF
--- a/custom_components/xtend_tuya/const.py
+++ b/custom_components/xtend_tuya/const.py
@@ -1163,6 +1163,7 @@ DPCODE_PREFERED_DEVICE_CLASS: dict[str, str | None] = {
     "ALARM_LOW_HUMID": "humidity",
     "AUTO_HIGH_HUMID": "humidity",
     "AUTO_LOW_HUMID": "humidity",
+    "hum_calibration": "humidity",
     "hum_sensitivity": "humidity",
     "humidity_now": "humidity",
     "humidity_set": "humidity",


### PR DESCRIPTION
## Problem
Devices with a `hum_calibration` DP code produce repeated warnings:

> Multiple possible device class {'moisture', 'humidity', 'power_factor', 'battery'}
> for unit % on device [...] (hum_calibration), unable to determine the most
> probable one, returning None.

`hum_calibration` was missing from `DPCODE_PREFERED_DEVICE_CLASS` in `const.py`, causing `determine_most_probable_device_class_from_uom()` to fall through to the warning branch and return `None`.

## Fix
Added `"hum_calibration": "humidity"` to `DPCODE_PREFERED_DEVICE_CLASS`, consistent with the existing `hum_sensitivity`, `huid_revise`, and other humidity-related DP codes already present in the dict.

## Affected devices
Temperature/Humidity sensors (e.g. TH05) using `hum_calibration` DP.