### PR TITLE
Fix battery device class ambiguity for generic sensors

### DIFF
--- a/custom_components/xtend_tuya/const.py
+++ b/custom_components/xtend_tuya/const.py
@@ -1194,6 +1194,12 @@ UOM_MAPPING_DICT: dict[str, str | None] = {
 DPCODE_PREFERED_DEVICE_CLASS: dict[str, str | None] = {
     "battery": "battery",
     "battery_percentage": "battery",
+    "battery_power": "battery",
+    "battery_state": "battery",
+    "battery_value": "battery",
+    "residual_electricity": "battery",
+    "va_battery": "battery",
+    "wireless_electricity": "battery",
     "maxco2_set": "carbon_dioxide",
     "motionless_far_detection": "distance",
     "breathe_detection": "distance",


### PR DESCRIPTION
Generic sensors reporting unit "%" trigger "Multiple possible device class" warnings because battery-related dpcodes aren't in the disambiguation dict. The code checks DPCODE_PREFERED_DEVICE_CLASS for explicit mappings, but battery dpcodes like residual_electricity, battery_percentage, and va_battery are missing.

This adds 6 battery-related dpcodes to the preferred device class mapping, resolving the ambiguity without changing behavior for non-battery sensors.

Fixes #915