### PR TITLE
fix(sensor): include temperature/humidity sensors for tdq device category

### DIFF
--- a/custom_components/xtend_tuya/sensor.py
+++ b/custom_components/xtend_tuya/sensor.py
@@ -1916,7 +1916,9 @@ SENSORS: dict[str, tuple[XTSensorEntityDescription, ...]] = {
 SENSORS["cz"] = SENSORS["kg"]
 SENSORS["wkcz"] = SENSORS["kg"]
 SENSORS["dlq"] = SENSORS["kg"]
-SENSORS["tdq"] = SENSORS["kg"]
+# tdq category is used by some multi-plug socket devices, but also by temperature/humidity sensors (e.g., Tuya T&H Sensor)
+# Include temperature, humidity, and battery sensors alongside the standard socket sensors
+SENSORS["tdq"] = (*SENSORS["kg"], *TEMPERATURE_SENSORS, *HUMIDITY_SENSORS, *BATTERY_SENSORS)
 SENSORS["pc"] = SENSORS["kg"]
 SENSORS["aqcz"] = SENSORS["kg"]
 SENSORS["zndb"] = SENSORS["kg"]


### PR DESCRIPTION
## Problem

The `tdq` category was mapped to `SENSORS["kg"]` (socket/switch sensors only). This prevented temperature and humidity sensor entities from being created for Tuya T&H Sensor devices that use the `tdq` category.

**Affected devices:** Tuya T&H Sensor (category `tdq`, e.g. device `ebd60b15aebe0ff158viqr`)

**Symptoms:**
- Device discovered via OpenAPI but no temperature/humidity/battery entities created
- Only switch-related entities (relay_status, countdown, etc.) were attempted

## Root Cause

`sensor.py` line ~1921:
```python
SENSORS["tdq"] = SENSORS["kg"]
```

The `kg` category covers smart sockets/plugs. `tdq` is shared with socket-like devices **and** T&H sensors that report `temp_current`, `humidity_value`, and `battery_state` DPs.

## Fix

```python
SENSORS["tdq"] = (*SENSORS["kg"], *TEMPERATURE_SENSORS, *HUMIDITY_SENSORS, *BATTERY_SENSORS)
```

## Testing

Verified with a Tuya T&H Sensor (category `tdq`):
- `sensor.temperature` → 24.5 °C ✅
- `sensor.humidity` → 58 % ✅
- `sensor.battery` → middle ✅

Existing socket entities in `tdq` are unaffected (they still appear if the device reports those DPs).