### PR TITLE
feat: allow project-token-only mode (no Tuya app username/password required)

### DIFF
--- a/custom_components/xtend_tuya/config_flow.py
+++ b/custom_components/xtend_tuya/config_flow.py
@@ -194,6 +194,24 @@ class XTConfigFlows:
             data[CONF_PASSWORD_OT] = None
             return {TUYA_RESPONSE_SUCCESS: True}, data
 
+        # No-user-api mode: if no username provided, skip app login and use project-level
+        # token only. This allows xtend_tuya to be configured with Tuya IoT Platform
+        # project credentials alone, without a Tuya app account.
+        if not data.get(CONF_USERNAME_OT, ""):
+            data[CONF_AUTH_TYPE] = AuthType.SMART_HOME
+            data[CONF_APP_TYPE] = TUYA_SMART_APP
+            _nonuser_api = XTIOTOpenAPI(
+                endpoint=data[CONF_ENDPOINT_OT],
+                access_id=data[CONF_ACCESS_ID_OT],
+                access_secret=data[CONF_ACCESS_SECRET_OT],
+                shared_token_info=TuyaTokenInfo(),
+                auth_type=AuthType.SMART_HOME,
+                non_user_specific_api=True,
+            )
+            _nonuser_api.set_dev_channel("hass")
+            _resp = _nonuser_api.connect()
+            return _resp, data
+
         for app_type in ("", TUYA_SMART_APP, SMARTLIFE_APP):
             data[CONF_APP_TYPE] = app_type
             if data[CONF_APP_TYPE] == "":

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_iot/init.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_iot/init.py
@@ -115,8 +115,6 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
             or CONF_ENDPOINT_OT not in config_entry.options
             or CONF_ACCESS_ID not in config_entry.options
             or CONF_ACCESS_SECRET not in config_entry.options
-            or CONF_USERNAME not in config_entry.options
-            or CONF_PASSWORD not in config_entry.options
             or CONF_COUNTRY_CODE not in config_entry.options
             or CONF_APP_TYPE not in config_entry.options
         ):
@@ -163,12 +161,33 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
                     non_user_api.connect
                 )
             )
-            if auth_type == AuthType.CUSTOM:
+            # No-user-api mode: if no username is configured, skip user login and use
+            # the non-user (project-level) API token for all API calls. This allows
+            # xtend_tuya to work with Tuya IoT Platform project credentials only,
+            # without requiring a Tuya app account username/password.
+            _username = config_entry.options.get(CONF_USERNAME, "")
+            if not _username:
+                connect_user_api = {"success": True}
+                user_api_valid = True
+                api = non_user_api
+                # The project-level token UID is a service account UID (bay...) which
+                # lacks permission to list user devices. Override with the stored user UID
+                # from config_entry.data so that device listing via /v1.0/users/{uid}/devices works.
+                stored_uid = (config_entry.data or {}).get("token_info", {}).get("uid", "")
+                if stored_uid:
+                    api.token_info.uid = stored_uid
+                    LOGGER.info(f"No-user API mode: using stored user UID {stored_uid} for device listing")
+            elif auth_type == AuthType.CUSTOM:
                 connect_user_api = (
                     await XTEventLoopProtector.execute_out_of_event_loop_and_return(
                         api.connect,
                         config_entry.options[CONF_USERNAME],
                         config_entry.options[CONF_PASSWORD],
+                    )
+                )
+                user_api_valid = (
+                    await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+                        api.test_validity
                     )
                 )
             else:
@@ -181,11 +200,11 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
                         config_entry.options[CONF_APP_TYPE],
                     )
                 )
-            user_api_valid = (
-                await XTEventLoopProtector.execute_out_of_event_loop_and_return(
-                    api.test_validity
+                user_api_valid = (
+                    await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+                        api.test_validity
+                    )
                 )
-            )
         except requests.exceptions.RequestException as e:
             LOGGER.error(f"Tuya IOT request didn't work: {e}")
             await self.raise_issue(


### PR DESCRIPTION
## Problem

xtend_tuya currently requires a Tuya app username and password to initialize. Users who have only Tuya IoT Platform project credentials (access_id + access_secret) — but no Tuya app account, or who wish to use the integration standalone — cannot use the OpenAPI features.

This is also a common scenario when the official `tuya` integration originally stored the user UID, but the user wants to run xtend_tuya independently.

## Solution

Add a **no-user project-token mode**: when `CONF_USERNAME` is empty, skip the per-user `api.connect()` call and use the non-user-specific (project-level) API token directly.

### Changes

**`config_flow.py`** — `_try_login_open_api()`:
- If no username is provided, connect using a project-level `non_user_specific_api` token and return success, skipping the app login loop.

**`init.py`** — `_init_from_entry()`:
- Remove `CONF_USERNAME` and `CONF_PASSWORD` from the required-fields guard (make them optional).
- If no username is configured: set `api = non_user_api`, skip `api.connect()` and `api.test_validity()`.
- Override `api.token_info.uid` with the stored user UID from `config_entry.data.token_info.uid`.

### Why the UID override?

The project-level token returns a service account UID (e.g. `bay1775...`) which lacks permission to call `/v1.0/users/{uid}/devices`. The stored user UID (from a prior app-login or manual setup) is used instead to restore device listing. A future improvement could add a `user_uid` field to the config flow for completely fresh installs.

## Testing

Tested with a Home Assistant instance where:
- Tuya IoT Platform project credentials configured (no app username/password)
- 7 devices discovered including T&H sensor, 3× smart switches, Fregadero, AC IR bridge
- All entities created correctly

## Related

- Fixes use case where official `tuya` integration is broken/unavailable but xtend_tuya should still work
- Combined with PR #941 (tdq sensor category fix), enables T&H sensor temperature/humidity entities