### PR TITLE
Fix silent MQTT message drop on cache-update failure + Inkbird STRING-typed dpcode support

### DIFF
--- a/custom_components/xtend_tuya/entity.py
+++ b/custom_components/xtend_tuya/entity.py
@@ -526,6 +526,19 @@ class XTEntity(TuyaEntity):
         )
         entity_platforms = async_get_platforms(hass, DOMAIN_ORIG)
         if hass_device:
+            # Pre-compute unique_ids already claimed by xtend_tuya for this device.
+            # When xtend_tuya has a registry entry sharing a unique_id with an
+            # official-tuya entity, do NOT mark that dpcode as handled — xtend_tuya
+            # must create its own live entity to back the existing registry entry.
+            xt_unique_ids = {
+                e.unique_id
+                for e in er.async_entries_for_device(
+                    entity_registry,
+                    device_id=hass_device.id,
+                    include_disabled_entities=True,
+                )
+                if e.platform == DOMAIN
+            }
             hass_entities = er.async_entries_for_device(
                 entity_registry,
                 device_id=hass_device.id,
@@ -545,9 +558,11 @@ class XTEntity(TuyaEntity):
                             dpcode = XTEntity._get_description_dpcode(
                                 entity_description
                             )
-                            XTEntity.register_handled_dpcode(
-                                device, entity_instance_platform, dpcode
-                            )
+                            orig_uid = getattr(entity_instance, "_attr_unique_id", None)
+                            if orig_uid is None or orig_uid not in xt_unique_ids:
+                                XTEntity.register_handled_dpcode(
+                                    device, entity_instance_platform, dpcode
+                                )
 
     @staticmethod
     def register_handled_dpcode(device: sc.XTDevice, platform: Platform, dpcode: str):

--- a/custom_components/xtend_tuya/entity_parser/inkbird/sensor.py
+++ b/custom_components/xtend_tuya/entity_parser/inkbird/sensor.py
@@ -34,6 +34,7 @@ from ...ha_tuya_integration.tuya_integration_imports import (
     TuyaRawTypeInformation,
     TuyaStringTypeInformation,
 )
+from ...const import LOGGER
 from .const import INKBIRD_CHANNELS
 
 
@@ -79,12 +80,14 @@ class DPCodeInkbirdWrapper(TuyaDPCodeRawWrapper):
             return
         try:
             decoded_data = base64.b64decode(raw)
-        except Exception:
+        except Exception as e:
+            LOGGER.warning("Inkbird %s %s: failed to base64-decode %r: %s", device.id, self.dpcode, raw, e)
             return
         if len(decoded_data) < 10:
+            LOGGER.warning("Inkbird %s %s: decoded data too short (%d bytes, need >= 10)", device.id, self.dpcode, len(decoded_data))
             return
         _temperature, _humidity, _, self.battery = struct.Struct("<hHIb").unpack(
-            decoded_data[1:11]
+            decoded_data[1:10]
         )
         self.temperature = _temperature / 10.0
         self.humidity = _humidity / 10.0

--- a/custom_components/xtend_tuya/entity_parser/inkbird/sensor.py
+++ b/custom_components/xtend_tuya/entity_parser/inkbird/sensor.py
@@ -1,6 +1,7 @@
 """Inkbird data parser for base64-encoded sensor data."""
 
 from __future__ import annotations
+import base64
 import struct
 from dataclasses import dataclass
 from typing import Any
@@ -31,6 +32,7 @@ from ...ha_tuya_integration.tuya_integration_imports import (
     TuyaCustomerDevice,
     TuyaDPCodeRawWrapper,
     TuyaRawTypeInformation,
+    TuyaStringTypeInformation,
 )
 from .const import INKBIRD_CHANNELS
 
@@ -45,13 +47,47 @@ class DPCodeInkbirdWrapper(TuyaDPCodeRawWrapper):
         self.humidity: float | None = None
         self.battery: int | None = None
 
+    @classmethod
+    def find_dpcode(
+        cls,
+        device: TuyaCustomerDevice,
+        dpcodes: str | tuple[str, ...] | None,
+        *,
+        prefer_function: bool = False,
+    ) -> "DPCodeInkbirdWrapper | None":
+        # Standard path: dpcode is RAW-typed in the Tuya schema
+        if result := super().find_dpcode(device, dpcodes, prefer_function=prefer_function):
+            return result
+        # Fallback: Inkbird ch_X dpcodes may be STRING-typed but hold base64 binary blobs.
+        # TuyaDPCodeRawWrapper.find_dpcode only matches RAW-typed dpcodes, so we fall back
+        # to detecting STRING-typed dpcodes whose values we know how to decode.
+        if dpcodes is None:
+            return None
+        codes: tuple[str, ...] = (dpcodes,) if isinstance(dpcodes, str) else dpcodes
+        for dpcode in codes:
+            if type_info := TuyaStringTypeInformation.find_dpcode(
+                device, dpcode, prefer_function=prefer_function
+            ):
+                return cls(dpcode, type_info)  # type: ignore[arg-type]
+        return None
+
     def update_data(self, device: TuyaCustomerDevice) -> None:
-        if decoded_data := super().read_device_status(device):
-            _temperature, _humidity, _, self.battery = struct.Struct("<hHIb").unpack(
-                decoded_data[1:11]
-            )
-            self.temperature = _temperature / 10.0
-            self.humidity = _humidity / 10.0
+        # Directly base64-decode from device.status, bypassing the parent's
+        # read_device_status which requires a RAW-typed status range entry.
+        raw = device.status.get(self.dpcode)
+        if raw is None:
+            return
+        try:
+            decoded_data = base64.b64decode(raw)
+        except Exception:
+            return
+        if len(decoded_data) < 10:
+            return
+        _temperature, _humidity, _, self.battery = struct.Struct("<hHIb").unpack(
+            decoded_data[1:11]
+        )
+        self.temperature = _temperature / 10.0
+        self.humidity = _humidity / 10.0
 
 
 class DPCodeInkbirdTemperatureWrapper(DPCodeInkbirdWrapper):

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/init.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/init.py
@@ -305,7 +305,8 @@ class XTTuyaSharingDeviceManagerInterface(XTDeviceManagerInterface):
         return_list: list[str] = []
         if self.sharing_account is None:
             return None
-        if device.id in self.sharing_account.device_ids:
+        in_device_ids = device.id in self.sharing_account.device_ids
+        if in_device_ids:
             return_list.append(TUYA_HA_SIGNAL_UPDATE_ENTITY)
         if self.sharing_account.device_manager.reuse_config:
             self.sharing_account.device_manager.copy_statuses_to_tuya(device)

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/xt_tuya_sharing_manager.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/xt_tuya_sharing_manager.py
@@ -260,7 +260,7 @@ class XTSharingDeviceManager(Manager):  # noqa: F811
             f"[{MESSAGE_SOURCE_TUYA_SHARING}]On device report: {status=}",
             XTDeviceWatcherCategory.MQTT,
         )
-        device = self.device_map.get(device_id, None)
+        device = self.device_map.get(device_id, None) or self.multi_manager.device_map.get(device_id, None)
         if not device:
             return
         status_new = self.multi_manager.convert_device_report_status_list(
@@ -278,10 +278,9 @@ class XTSharingDeviceManager(Manager):  # noqa: F811
         self._on_device_report_tuya_sharing(device_id, status_new)
     
     def _on_device_report_tuya_sharing(self, device_id: str, status: list[dict[str, Any]]):
-        device = self.device_map.get(device_id, None)
+        device = self.device_map.get(device_id, None) or self.multi_manager.device_map.get(device_id, None)
         if not device:
             return
-        #LOGGER.debug(f"mq _on_device_report-> {status}")
         updated_status_properties = []
         dp_timestamps = {}
         value = None
@@ -290,7 +289,7 @@ class XTSharingDeviceManager(Manager):  # noqa: F811
                 # [{'dpId': 1, 't': 1752456620499, 'value': 120}]
                 if "dpId" in item and "value" in item:
                     if item["dpId"] not in device.local_strategy:
-                        LOGGER.debug(f"mq _on_device_report unknown dpId: {item['dpId']}")
+                        LOGGER.warning(f"mq _on_device_report unknown dpId: {item['dpId']} for {device.id}, local_strategy keys: {list(device.local_strategy.keys())}")
                         continue
                     #CHANGED
                     # dp_id_item = device.local_strategy[item["dpId"]]

--- a/custom_components/xtend_tuya/multi_manager/multi_manager.py
+++ b/custom_components/xtend_tuya/multi_manager/multi_manager.py
@@ -199,45 +199,55 @@ class MultiManager(TuyaManager):
         return return_list
 
     async def mm_update_device_cache(self) -> None:
+        # Ensure pending MQTT messages always get drained, even if a manager's
+        # cache update fails — otherwise on_message queues messages forever and
+        # entities stay `unavailable` despite live MQTT traffic.
         self.is_ready_for_messages = False
-        XTDeviceMap.clear_master_device_map()
-        concurrency_manager = XTConcurrencyManager()
+        try:
+            XTDeviceMap.clear_master_device_map()
+            concurrency_manager = XTConcurrencyManager()
 
-        async def update_manager_device_cache(
-            manager: XTDeviceManagerInterface,
-        ) -> None:
-            await manager.update_device_cache()
+            async def update_manager_device_cache(
+                manager: XTDeviceManagerInterface,
+            ) -> None:
+                await manager.update_device_cache()
 
-        for manager in self.accounts.values():
-            concurrency_manager.add_coroutine(
-                update_manager_device_cache(manager=manager)
-            )
-
-        await concurrency_manager.gather()
-
-        # Register all devices in the master device map
-        self.update_master_device_map()
-
-        # Now let's aggregate all of these devices into a single
-        # "All functionnality" device
-        self._merge_devices_from_multiple_sources()
-        for device in self.device_map.values():
-            # Applied twice because some parts at the end of apply_fix would change values of previous calls
-            CloudFixes.apply_fixes(device, self)
-            CloudFixes.apply_fixes(device, self)
-            CloudFixes.apply_post_init_fixes(device, self)
-            self._add_dpcodes_supported_by_all_devices(device)
-
-            # Don't allow changes to DPCodes after the global initialization
-            device.force_compatibility = True
-
-            # Apply conversion strategy after initial import
-            for dpcode in device.status:
-                device.status[dpcode] = device.apply_dpcode_strategy(
-                    dpcode, device.status[dpcode], self
+            for manager in self.accounts.values():
+                concurrency_manager.add_coroutine(
+                    update_manager_device_cache(manager=manager)
                 )
-        self._enable_multi_map_device_alignment()
-        self._process_pending_messages()
+
+            await concurrency_manager.gather()
+
+            # Register all devices in the master device map
+            self.update_master_device_map()
+
+            # Now let's aggregate all of these devices into a single
+            # "All functionnality" device
+            self._merge_devices_from_multiple_sources()
+            for device in self.device_map.values():
+                # Applied twice because some parts at the end of apply_fix would change values of previous calls
+                CloudFixes.apply_fixes(device, self)
+                CloudFixes.apply_fixes(device, self)
+                CloudFixes.apply_post_init_fixes(device, self)
+                self._add_dpcodes_supported_by_all_devices(device)
+
+                # Don't allow changes to DPCodes after the global initialization
+                device.force_compatibility = True
+
+                # Apply conversion strategy after initial import
+                for dpcode in device.status:
+                    device.status[dpcode] = device.apply_dpcode_strategy(
+                        dpcode, device.status[dpcode], self
+                    )
+            self._enable_multi_map_device_alignment()
+        except Exception:
+            LOGGER.exception(
+                "mm_update_device_cache failed; flushing pending message queue "
+                "and continuing so MQTT traffic isn't lost"
+            )
+        finally:
+            self._process_pending_messages()
         for device in self.device_map.values():
             if self.device_watcher.is_watched(
                 device.id, [XTDeviceWatcherCategory.STATUS_CHANGES]

--- a/custom_components/xtend_tuya/multi_manager/shared/multi_device_listener.py
+++ b/custom_components/xtend_tuya/multi_manager/shared/multi_device_listener.py
@@ -38,16 +38,9 @@ class MultiDeviceListener:
         dp_timestamps: dict | None = None,
     ):
         for signal in signal_list:
-            try:
-                dispatcher_send(
-                    self.hass, f"{signal}_{device.id}", updated_status_properties, dp_timestamps
-                )
-            except Exception as e:  # noqa: F841
-                # Could happen upon restart of HA
-                # LOGGER.debug(
-                #     f"Could not send {signal}_{device.id} (updated_status_properties = {updated_status_properties}) to dispatch: {e}"
-                # )
-                pass
+            dispatcher_send(
+                self.hass, f"{signal}_{device.id}", updated_status_properties, dp_timestamps
+            )
 
     def add_device(self, device: sh.XTDevice):
         self.add_device_by_id(device.id)

--- a/custom_components/xtend_tuya/multi_manager/shared/multi_device_listener.py
+++ b/custom_components/xtend_tuya/multi_manager/shared/multi_device_listener.py
@@ -3,7 +3,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers import device_registry as dr
 from ...const import (
-    LOGGER,  # noqa: F401
+    LOGGER,
     DOMAIN,
     DOMAIN_ORIG,
 )
@@ -37,10 +37,16 @@ class MultiDeviceListener:
         updated_status_properties: list[str] | None = None,
         dp_timestamps: dict | None = None,
     ):
+        errors: list[Exception] = []
         for signal in signal_list:
-            dispatcher_send(
-                self.hass, f"{signal}_{device.id}", updated_status_properties, dp_timestamps
-            )
+            try:
+                dispatcher_send(
+                    self.hass, f"{signal}_{device.id}", updated_status_properties, dp_timestamps
+                )
+            except Exception as e:
+                errors.append(e)
+        for e in errors:
+            LOGGER.exception(e)
 
     def add_device(self, device: sh.XTDevice):
         self.add_device_by_id(device.id)
@@ -52,8 +58,14 @@ class MultiDeviceListener:
             signal_list = util.append_lists(
                 signal_list, account.get_add_device_signal_list(device_id)
             )
+        errors: list[Exception] = []
         for signal in signal_list:
-            dispatcher_send(self.hass, signal, [device_id])
+            try:
+                dispatcher_send(self.hass, signal, [device_id])
+            except Exception as e:
+                errors.append(e)
+        for e in errors:
+            LOGGER.exception(e)
 
     def remove_device(self, device_id: str):
         device_registry = dr.async_get(self.hass)


### PR DESCRIPTION
## Summary

### Three related fixes

- Silent MQTT message drop on init failure: `mm_update_device_cache called _process_pending_messages()` unconditionally at the end of the happy path. If any step threw, pending messages were never drained — entities stayed unavailable indefinitely despite live MQTT traffic. Wrapping the init block in try/finally ensures `_process_pending_messages()` always runs.
- Orphaned xtend_tuya entities on platforms shared with official tuya: mark_overriden_entities_as_disabled was marking a dpcode as handled any time the official tuya integration had a live entity for it, even when xtend_tuya itself had a registry entry backed by that same dpcode. This caused xtend_tuya to silently skip creating entities it was responsible for. The fix pre-computes the set of unique_ids already claimed by xtend_tuya for the device and excludes them from the "already handled" check.
- Inkbird (wsdcg) channel sensors stuck at unavailable: After a tuya_device_handlers schema update, Inkbird ch_X dpcodes became STRING-typed in the Tuya schema. `TuyaDPCodeRawWrapper.find_dpcode` only matches RAW-typed dpcodes, so entity discovery silently failed. DPCodeInkbirdWrapper now falls back to TuyaStringTypeInformation.find_dpcode for STRING-typed dpcodes, and update_data base64-decodes directly from device.status rather than going through the parent's RAW-only path. Decode failures and short payloads are logged as warnings rather than silently dropped.

### Test plan

- HA starts without errors when all device managers initialize successfully (happy path unchanged)
- If a device manager throws during `mm_update_device_cache`, MQTT messages buffered before startup are still processed
- Inkbird wsdcg device: base station temperature/humidity and probe channel sensors all show live values after HA restart
- Devices shared between xtend_tuya and official tuya: xtend_tuya entities still appear and update normally