### PR TITLE
Fix orphaned xtend_tuya entities on platforms shared with official tuya

### DIFF
--- a/custom_components/xtend_tuya/entity.py
+++ b/custom_components/xtend_tuya/entity.py
@@ -526,6 +526,19 @@ class XTEntity(TuyaEntity):
         )
         entity_platforms = async_get_platforms(hass, DOMAIN_ORIG)
         if hass_device:
+            # Pre-compute unique_ids already claimed by xtend_tuya for this device.
+            # When xtend_tuya has a registry entry sharing a unique_id with an
+            # official-tuya entity, do NOT mark that dpcode as handled — xtend_tuya
+            # must create its own live entity to back the existing registry entry.
+            xt_unique_ids = {
+                e.unique_id
+                for e in er.async_entries_for_device(
+                    entity_registry,
+                    device_id=hass_device.id,
+                    include_disabled_entities=True,
+                )
+                if e.platform == DOMAIN
+            }
             hass_entities = er.async_entries_for_device(
                 entity_registry,
                 device_id=hass_device.id,
@@ -545,9 +558,11 @@ class XTEntity(TuyaEntity):
                             dpcode = XTEntity._get_description_dpcode(
                                 entity_description
                             )
-                            XTEntity.register_handled_dpcode(
-                                device, entity_instance_platform, dpcode
-                            )
+                            orig_uid = getattr(entity_instance, "_attr_unique_id", None)
+                            if orig_uid is None or orig_uid not in xt_unique_ids:
+                                XTEntity.register_handled_dpcode(
+                                    device, entity_instance_platform, dpcode
+                                )
 
     @staticmethod
     def register_handled_dpcode(device: sc.XTDevice, platform: Platform, dpcode: str):

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/init.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/init.py
@@ -305,7 +305,8 @@ class XTTuyaSharingDeviceManagerInterface(XTDeviceManagerInterface):
         return_list: list[str] = []
         if self.sharing_account is None:
             return None
-        if device.id in self.sharing_account.device_ids:
+        in_device_ids = device.id in self.sharing_account.device_ids
+        if in_device_ids:
             return_list.append(TUYA_HA_SIGNAL_UPDATE_ENTITY)
         if self.sharing_account.device_manager.reuse_config:
             self.sharing_account.device_manager.copy_statuses_to_tuya(device)

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/xt_tuya_sharing_manager.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/xt_tuya_sharing_manager.py
@@ -260,7 +260,7 @@ class XTSharingDeviceManager(Manager):  # noqa: F811
             f"[{MESSAGE_SOURCE_TUYA_SHARING}]On device report: {status=}",
             XTDeviceWatcherCategory.MQTT,
         )
-        device = self.device_map.get(device_id, None)
+        device = self.device_map.get(device_id, None) or self.multi_manager.device_map.get(device_id, None)
         if not device:
             return
         status_new = self.multi_manager.convert_device_report_status_list(
@@ -278,10 +278,9 @@ class XTSharingDeviceManager(Manager):  # noqa: F811
         self._on_device_report_tuya_sharing(device_id, status_new)
     
     def _on_device_report_tuya_sharing(self, device_id: str, status: list[dict[str, Any]]):
-        device = self.device_map.get(device_id, None)
+        device = self.device_map.get(device_id, None) or self.multi_manager.device_map.get(device_id, None)
         if not device:
             return
-        #LOGGER.debug(f"mq _on_device_report-> {status}")
         updated_status_properties = []
         dp_timestamps = {}
         value = None
@@ -290,7 +289,7 @@ class XTSharingDeviceManager(Manager):  # noqa: F811
                 # [{'dpId': 1, 't': 1752456620499, 'value': 120}]
                 if "dpId" in item and "value" in item:
                     if item["dpId"] not in device.local_strategy:
-                        LOGGER.debug(f"mq _on_device_report unknown dpId: {item['dpId']}")
+                        LOGGER.warning(f"mq _on_device_report unknown dpId: {item['dpId']} for {device.id}, local_strategy keys: {list(device.local_strategy.keys())}")
                         continue
                     #CHANGED
                     # dp_id_item = device.local_strategy[item["dpId"]]


### PR DESCRIPTION
When xtend_tuya runs alongside the official tuya integration, the register_current_entities_as_handled_dpcode walk would mark every dpcode owned by an official-tuya live entity as "handled" — even when the HA entity registry already held an xtend_tuya entry for that same unique_id. This left xtend_tuya registry entries permanently orphaned (unavailable) despite live MQTT traffic.

Fix: pre-compute the set of unique_ids already claimed by xtend_tuya for this device. Skip register_handled_dpcode for any dpcode whose unique_id is already in that set, so xtend_tuya creates its own live entity to back the pre-existing registry entry.

Also extend the device lookup in XTSharingDeviceManager._on_device_report to fall back to multi_manager.device_map when the device is not present in the sharing manager's own device_map, preventing silent MQTT report drops for devices registered through a different account path.