### PR TITLE
fix: prevent AttributeError in TuyaOptionFlow when runtime_data not set

### DIFF
--- a/custom_components/xtend_tuya/config_flow.py
+++ b/custom_components/xtend_tuya/config_flow.py
@@ -353,9 +353,10 @@ class TuyaOptionFlow(OptionsFlow):
         self.selected_device_id: str | None = None
         self.selected_device_next_step_id: str | None = None
         self._device_options: dict[str, str] = {}
+        _runtime_data = getattr(config_entry, "runtime_data", None)
         self.multi_manager: mm.MultiManager | None = (
-            getattr(config_entry.runtime_data, "multi_manager")
-            if config_entry.runtime_data
+            getattr(_runtime_data, "multi_manager", None)
+            if _runtime_data is not None
             else None
         )
         if config_entry.options is not None:


### PR DESCRIPTION
## Problem

`TuyaOptionFlow.__init__` accesses `config_entry.runtime_data` directly:

```python
self.multi_manager = (
    getattr(config_entry.runtime_data, "multi_manager")
    if config_entry.runtime_data
    else None
)
```

In HA 2024.x+, `ConfigEntry.runtime_data` is a property that raises `AttributeError` when the integration has not yet completed `async_setup_entry`. The boolean check `if config_entry.runtime_data` does **not** protect against this — the attribute access itself in that expression already throws.

**When does this happen?**
- Opening the options flow immediately after HA restart (before xtend_tuya finishes loading)
- Reloading xtend_tuya while the options flow is open
- Race condition when the official Tuya integration loads after xtend_tuya

**Symptom:** HTTP 500 / unhandled `AttributeError` traceback in HA logs.

## Fix

Use `getattr(config_entry, "runtime_data", None)` to safely retrieve the attribute without raising, then guard against `None` before accessing `multi_manager`.

```python
_runtime_data = getattr(config_entry, "runtime_data", None)
self.multi_manager: mm.MultiManager | None = (
    getattr(_runtime_data, "multi_manager", None)
    if _runtime_data is not None
    else None
)
```

This is a one-line-equivalent behavioural change: when `runtime_data` is not yet set, `multi_manager` is `None` and the options flow gracefully aborts device-dependent steps via the existing `if self.multi_manager is None: return self.async_abort(...)` guards already in the code.

## Testing

Tested on Home Assistant 2026.5.1 with xtend_tuya 4.4.7 on Jetson Nano (ARM64). Confirmed the options flow opens without error after HA restart.