### PR TITLE
fix: Add support for 'Cool' and 'Fan' HVAC modes

### DIFF
--- a/custom_components/xtend_tuya/climate.py
+++ b/custom_components/xtend_tuya/climate.py
@@ -74,6 +74,7 @@ XT_HVAC_TUYA_TO_TUYALIB = {
     "auto": TuyaClimateHVACMode.AUTO,
     "cold": TuyaClimateHVACMode.COOL,
     "cool": TuyaClimateHVACMode.COOL,
+    "Cool": TuyaClimateHVACMode.COOL,
     "dehumidify": TuyaClimateHVACMode.DRY,
     "Eco": TuyaClimateHVACMode.HEAT_COOL,
     "Fan": TuyaClimateHVACMode.FAN_ONLY,


### PR DESCRIPTION
Add Support for "Cool" from COSTWAY climate 5 in 1 device.
Problem: Climate devices that send "Cool" (capital C) via DPS show unknown state in HA, because only "cool" (lowercase) is mapped in XT_HVAC_TUYA_TO_TUYALIB. The equivalent "Heat" (capital H) is already mapped correctly.

Fix: Added "Cool": TuyaClimateHVACMode.COOL to the mapping dictionary, consistent with the existing "Heat" entry.

Tested with: Device ProductKey 88h9lkn30fuca8ta (split AC unit)

