### PR TITLE
feat(locks): support Ticket flow unlock method and overhaul documenta…

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+  "default": true
+}

--- a/custom_components/xtend_tuya/const.py
+++ b/custom_components/xtend_tuya/const.py
@@ -195,6 +195,7 @@ class XTLockingMechanism(StrEnum):
     AUTO = "auto"
     DOOR_OPEN = "door_open"
     DOOR_OPERATE = "door_operate"
+    TICKET_FLOW = "ticket_flow"
     DPCODE_COMMAND = "dpcode_command"
 
     def get_human_name(self, value: str) -> str:
@@ -205,6 +206,8 @@ class XTLockingMechanism(StrEnum):
                 return "door_open API"
             case XTLockingMechanism.DOOR_OPERATE:
                 return "door_operate API"
+            case XTLockingMechanism.TICKET_FLOW:
+                return "Ticket flow API"
             case XTLockingMechanism.DPCODE_COMMAND:
                 return "DPCode command"
             case _:

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_iot/xt_tuya_iot_manager.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_iot/xt_tuya_iot_manager.py
@@ -638,6 +638,12 @@ class XTIOTDeviceManager(TuyaDeviceManager):
             )
         return False
 
+    def _lock_unlock_command_ticket_flow(
+        self, device: XTDevice, lock: bool, api: XTIOTOpenAPI
+    ) -> bool:
+        # Request password ticket and run door-operate with standard boolean value
+        return self.call_door_operate(device, not lock, api)
+
     def send_lock_unlock_command_multi_api(
         self,
         device: XTDevice,
@@ -664,6 +670,8 @@ class XTIOTDeviceManager(TuyaDeviceManager):
                 return self._lock_unlock_command_door_open(
                     device, lock, api, self.get_supported_unlock_types(device, api)
                 )
+            case XTLockingMechanism.TICKET_FLOW:
+                return self._lock_unlock_command_ticket_flow(device, lock, api)
             case XTLockingMechanism.DPCODE_COMMAND:
                 return self._lock_unlock_command_dpcode_command(device, lock, api)
             case _:
@@ -676,6 +684,8 @@ class XTIOTDeviceManager(TuyaDeviceManager):
                 if self._lock_unlock_command_door_open(device, lock, api, unlock_types):
                     return True
                 if self._lock_unlock_command_dpcode_command(device, lock, api):
+                    return True
+                if self._lock_unlock_command_ticket_flow(device, lock, api):
                     return True
         return False
 
@@ -1054,7 +1064,7 @@ class XTIOTDeviceManager(TuyaDeviceManager):
                 return ticket_id
         return None
 
-    def call_door_operate(self, device: XTDevice, open: str, api: XTIOTOpenAPI) -> bool:
+    def call_door_operate(self, device: XTDevice, open: str | bool, api: XTIOTOpenAPI) -> bool:
         if ticket_id := self.get_door_lock_password_ticket(device, api):
             api_to_use = cast(
                 XTIOTOpenAPI,

--- a/custom_components/xtend_tuya/strings.json
+++ b/custom_components/xtend_tuya/strings.json
@@ -1636,6 +1636,7 @@
                     "auto": "Automatic",
                     "door_open": "Door open",
                     "door_operate": "Door operate",
+                    "ticket_flow": "Ticket flow",
                     "dpcode_command": "DPcode command"
                 }
             }
@@ -2791,6 +2792,7 @@
                     "auto": "Automatic",
                     "door_open": "Door open",
                     "door_operate": "Door operate",
+                    "ticket_flow": "Ticket flow",
                     "dpcode_command": "DPcode command"
                 }
             }

--- a/custom_components/xtend_tuya/translations/en.json
+++ b/custom_components/xtend_tuya/translations/en.json
@@ -1636,6 +1636,7 @@
                     "auto": "Automatic",
                     "door_open": "Door open",
                     "door_operate": "Door operate",
+                    "ticket_flow": "Ticket flow",
                     "dpcode_command": "DPcode command"
                 }
             }
@@ -2791,6 +2792,7 @@
                     "auto": "Automatic",
                     "door_open": "Door open",
                     "door_operate": "Door operate",
+                    "ticket_flow": "Ticket flow",
                     "dpcode_command": "DPcode command"
                 }
             }

--- a/docs/cloud_credentials.md
+++ b/docs/cloud_credentials.md
@@ -1,76 +1,89 @@
-# Purpose
-The purpose of this documentation is to be able to configure the Tuya IOT Platform cloud credentials in Xtend Tuya.
+# Cloud credentials
 
-# READ THIS CAREFULLY
-Some initial configurations have to be done right the first time, this is because they are a pain to update afterward if you got them wrong.<br/>
-To be prepared, please determine your correct data center:<br/>
-- If in Europe: Central Europe Data Center<br/>
-- If in US: Western America Data Center<br/>
-- If in China: China Data Center<br/>
-- If in India: India Data Center<br/>
+## Purpose
 
-DO NOT USE THE WESTERN EUROPE OR EASTERN AMERICA DATA CENTERS, THEY ARE RESERVED FOR BUSINESS CONSUMERS<br/>
+The purpose of this documentation is to be able to configure the Tuya IOT
+Platform cloud credentials in Xtend Tuya.
 
-# Steps
-1- Create your Tuya IOT Platform account<br/>
-1.1- Go to https://iot.tuya.com/<br/>
-1.2- Create your account<br/>
-1.3- Login to your newly created account<br/>
+## READ THIS CAREFULLY
 
-2- Create a development project<br/>
-2.1- On the left, hover over Cloud then select Project Management:<br/>
-![image](https://github.com/user-attachments/assets/8c62729b-2dc0-4b12-aadc-cb4c0b00b35a)<br/>
-2.2- Click "Create Cloud Project"<br/>
-2.3- Give any relevant name and description to your project<br/>
-2.4- Set "Smart home" in both "Industry" and "Development Method"<br/>
-2.5- Set the correct data center (Refer to the notes at the beginning of the development to do so, this is very important!)<br/>
-![image](https://github.com/user-attachments/assets/0459d8c2-a559-4665-b789-2f01b244c798)<br/>
-2.6- Click "Create"<br/>
-2.7- In the next screen, click "Authorize"<br/>
-![image](https://github.com/user-attachments/assets/8908079f-13f1-4231-9af7-3def0633ef8a)<br/>
+Some initial configurations have to be done right the first time, this is
+because they are a pain to update afterward if you got them wrong.
+To be prepared, please determine your correct data center:
 
-3- Link you Tuya/SmartLife app to your cloud account<br/>
-3.1- On the left, hover over Cloud then select Project Management:<br/>
-![image](https://github.com/user-attachments/assets/8c62729b-2dc0-4b12-aadc-cb4c0b00b35a)<br/>
-3.2- Open your cloud project created in step 2 by clicking the "Open Project" link<br/>
-![image](https://github.com/user-attachments/assets/9d3abb65-392b-435a-a5cb-14afa15b4bba)<br/>
-3.3- Go to the "Devices" tab<br/>
-![image](https://github.com/user-attachments/assets/e34bb6e7-e525-4532-a150-3d977f69df4e)<br/>
-3.4- Click the "Link App Account"<br/>
-![image](https://github.com/user-attachments/assets/a6cf3c6f-2aea-4d55-a4ea-1bfa98b9aba9)<br/>
-3.5- Click the "Add App Account"<br/>
-![image](https://github.com/user-attachments/assets/ea2155ce-8d72-41fb-aaec-c0bf1019ee2f)<br/>
-3.6- Open your Tuya/SmartLife app, go to the "Profile" and use the Scan Barcode button on the top right<br/>
-3.7- Scan the QR code generated in step 3.5 with your smartphone and approve the connection<br/>
-3.8- In the next screen, select "Automatic Link" and click OK<br/>
-![image](https://github.com/user-attachments/assets/955971f3-d0f3-4112-adf6-f70150fc4bc4)<br/>
-3.9- In the end, you should have something that looks like this:<br/>
-![image](https://github.com/user-attachments/assets/e75c5da8-4523-40f9-98d6-3b1f97b0c1fa)<br/>
+- If in Europe: Central Europe Data Center
+- If in US: Western America Data Center
+- If in China: China Data Center
+- If in India: India Data Center
 
-4- Gather the information needed by XT Tuya<br/>
-4.1- In the screen of 3.9, copy the value under the column "App Account" in a notepad<br/>
-![image](https://github.com/user-attachments/assets/43c8de07-890d-4b31-992a-c6b11d39d32f)<br/>
-4.2- Go to the Overview tab and copy the values of Client ID and Client Secret in a notepad<br/>
-![image](https://github.com/user-attachments/assets/20146f3b-36dd-43af-b283-c3e6d99f47cc)<br/>
+DO NOT USE THE WESTERN EUROPE OR EASTERN AMERICA DATA CENTERS, THEY ARE RESERVED
+FOR BUSINESS CONSUMERS\
 
-5- Enter your credentials in eXtend Tuya<br/>
-5.1- Go to the Settings page in HA<br/>
-![image](https://github.com/user-attachments/assets/57ac6999-742b-4622-9ad2-7a9670ebd1f7)<br/>
-5.2- Go to "Device & services"<br/>
-![image](https://github.com/user-attachments/assets/aa3a20aa-ae0a-4341-9d9a-4ffed4e0c7a1)<br/>
-5.3- Click on "Xtend Tuya"<br/>
-![image](https://github.com/user-attachments/assets/462d302a-7154-4fc3-ada9-e766aa0b5d4b)<br/>
-5.4- Click on the "Configure" button next to the account you want to configure<br/>
-![image](https://github.com/user-attachments/assets/be1e0eec-3743-4f7c-8497-eabbd2992fcb)<br/>
-5.5- In the popup, enter the following information<br/>
-- Country is the country you are in<br/>
-- Tuya IoT Access ID is the Client ID you retrieved in step 4.2<br/>
-- Tuya IoT Access Secret is the Client Secret you retrieved in step 4.2<br/>
-- SmartLife/Tuya account is the App Account you retrieved in step 4.1<br/>
-- SmartLife/Tuya account password is the password you use when logging in the SmartLife/Tuya app on your smartphone<br/>
-![image](https://github.com/user-attachments/assets/da4fb3d8-8fb5-4cf1-8ab2-d8a54c0bced0)<br/>
-5.6- Click Submit, if everything went correctly you should have a success message<br/>
-![image](https://github.com/user-attachments/assets/21c042a9-025b-4a52-9f31-bc3e30d2ba26)<br/>
+## Steps
+
+1- Create your Tuya IOT Platform account\
+1.1- Go to <https://iot.tuya.com/>\
+1.2- Create your account\
+1.3- Login to your newly created account
+
+2- Create a development project\
+2.1- On the left, hover over Cloud then select Project Management:\
+![image](https://github.com/user-attachments/assets/8c62729b-2dc0-4b12-aadc-cb4c0b00b35a)\
+2.2- Click "Create Cloud Project"\
+2.3- Give any relevant name and description to your project\
+2.4- Set "Smart home" in both "Industry" and "Development Method"\
+2.5- Set the correct data center (Refer to the notes at the beginning of the
+development to do so, this is very important!)\
+![image](https://github.com/user-attachments/assets/0459d8c2-a559-4665-b789-2f01b244c798)\
+2.6- Click "Create"\
+2.7- In the next screen, click "Authorize"\
+![image](https://github.com/user-attachments/assets/8908079f-13f1-4231-9af7-3def0633ef8a)
+
+3- Link you Tuya/SmartLife app to your cloud account\
+3.1- On the left, hover over Cloud then select Project Management:\
+![image](https://github.com/user-attachments/assets/8c62729b-2dc0-4b12-aadc-cb4c0b00b35a)\
+3.2- Open your cloud project created in step 2 by clicking the "Open Project" link\
+![image](https://github.com/user-attachments/assets/9d3abb65-392b-435a-a5cb-14afa15b4bba)\
+3.3- Go to the "Devices" tab\
+![image](https://github.com/user-attachments/assets/e34bb6e7-e525-4532-a150-3d977f69df4e)\
+3.4- Click the "Link App Account"\
+![image](https://github.com/user-attachments/assets/a6cf3c6f-2aea-4d55-a4ea-1bfa98b9aba9)\
+3.5- Click the "Add App Account"\
+![image](https://github.com/user-attachments/assets/ea2155ce-8d72-41fb-aaec-c0bf1019ee2f)\
+3.6- Open your Tuya/SmartLife app, go to the "Profile" and use the Scan Barcode
+button on the top right\
+3.7- Scan the QR code generated in step 3.5 with your smartphone and approve the
+connection\
+3.8- In the next screen, select "Automatic Link" and click OK\
+![image](https://github.com/user-attachments/assets/955971f3-d0f3-4112-adf6-f70150fc4bc4)\
+3.9- In the end, you should have something that looks like this:\
+![image](https://github.com/user-attachments/assets/e75c5da8-4523-40f9-98d6-3b1f97b0c1fa)
+
+4- Gather the information needed by XT Tuya\
+4.1- In the screen of 3.9, copy the value under the column "App Account" in a notepad\
+![image](https://github.com/user-attachments/assets/43c8de07-890d-4b31-992a-c6b11d39d32f)\
+4.2- Go to the Overview tab and copy the values of Client ID and Client Secret
+in a notepad\
+![image](https://github.com/user-attachments/assets/20146f3b-36dd-43af-b283-c3e6d99f47cc)
+
+5- Enter your credentials in eXtend Tuya\
+5.1- Go to the Settings page in HA\
+![image](https://github.com/user-attachments/assets/57ac6999-742b-4622-9ad2-7a9670ebd1f7)\
+5.2- Go to "Device & services"\
+![image](https://github.com/user-attachments/assets/aa3a20aa-ae0a-4341-9d9a-4ffed4e0c7a1)\
+5.3- Click on "Xtend Tuya"\
+![image](https://github.com/user-attachments/assets/462d302a-7154-4fc3-ada9-e766aa0b5d4b)\
+5.4- Click on the "Configure" button next to the account you want to configure\
+![image](https://github.com/user-attachments/assets/be1e0eec-3743-4f7c-8497-eabbd2992fcb)\
+5.5- In the popup, enter the following information
+
+- Country is the country you are in
+- Tuya IoT Access ID is the Client ID you retrieved in step 4.2
+- Tuya IoT Access Secret is the Client Secret you retrieved in step 4.2
+- SmartLife/Tuya account is the App Account you retrieved in step 4.1
+- SmartLife/Tuya account password is the password you use when logging in the
+SmartLife/Tuya app on your smartphone\
+![image](https://github.com/user-attachments/assets/da4fb3d8-8fb5-4cf1-8ab2-d8a54c0bced0)\
+5.6- Click Submit, if everything went correctly you should have a success message\
+![image](https://github.com/user-attachments/assets/21c042a9-025b-4a52-9f31-bc3e30d2ba26)\
 5.7- Restart your Home Assistant and enjoy!
-
-

--- a/docs/configure_cameras.md
+++ b/docs/configure_cameras.md
@@ -1,18 +1,26 @@
-# Purpose
-The purpose of this documentation is to correctly configure your cameras using the Tuya IOT Cloud platform
+# Configure cameras
 
-# Prerequisite
-For this, you will need a functionning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Steps
-1- Log in your Tuya IOT Cloud Platform account (https://iot.tuya.com/)<br/>
-2- Hover on Cloud and select "Cloud Services"<br/>
-![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)<br/>
-3- In the list, find the line that says "IoT Video Live Stream" and click the "Free Trial" link<br/>
-![image](https://github.com/user-attachments/assets/5d8ae9d2-141e-436f-b459-324663974e91)<br/>
-4- Select "Continue"<br/>
-![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)<br/>
-5- Verify that the "IoT Video Live Stream" is activated:<br/>
-![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)<br/>
-6- You should now be able to use cameras via WebRTC using Xtend Tuya<br/>
+The purpose of this documentation is to correctly configure your cameras using
+the Tuya IOT Cloud platform
+
+## Prerequisite
+
+For this, you will need a functionning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Steps
+
+1- Log in your Tuya IOT Cloud Platform account (<https://iot.tuya.com/>)\
+2- Hover on Cloud and select "Cloud Services"\
+![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)\
+3- In the list, find the line that says "IoT Video Live Stream" and click the
+"Free Trial" link\
+![image](https://github.com/user-attachments/assets/5d8ae9d2-141e-436f-b459-324663974e91)\
+4- Select "Continue"\
+![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)\
+5- Verify that the "IoT Video Live Stream" is activated:\
+![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)\
+6- You should now be able to use cameras via WebRTC using Xtend Tuya

--- a/docs/configure_energy_sensor_statistics.md
+++ b/docs/configure_energy_sensor_statistics.md
@@ -1,19 +1,26 @@
-# Purpose
-The purpose of this documentation is to correctly configure your energy sensors using the Tuya IOT Cloud platform
+# Configure energy sensor statistics
 
-# Prerequisite
-For this, you will need a functioning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Steps
-1- Log in your Tuya IOT Cloud Platform account (https://iot.tuya.com/)<br/> (In some countries you need to use this url instead: (https://platform.tuya.com/)<br/>
-2- Hover on Cloud and select "Cloud Services"<br/>
-![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)<br/>
-3- In the list, find the line that says "Beta APIs" and click the "Free Trial" link<br/>
-<img width="1847" height="557" alt="image" src="https://github.com/user-attachments/assets/40c3f9da-ccd5-4d6a-b8b0-759baa753d47" /><br/>
-4- Select "Continue"<br/>
-<img width="1268" height="391" alt="image" src="https://github.com/user-attachments/assets/4d4ac605-b9fa-4aff-8fad-0669a22a7c9b" /><br/>
-5- Verify that the "Beta APIs" is activated:<br/>
-<img width="1810" height="660" alt="image" src="https://github.com/user-attachments/assets/9f8514a2-35f2-4b1e-84b7-7ae061420ae2" /><br/>
-6- You should now be able to import energy consumption statistics using Xtend Tuya<br/>
+The purpose of this documentation is to correctly configure your energy sensors
+using the Tuya IOT Cloud platform
 
+## Prerequisite
+
+For this, you will need a functioning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Steps
+
+1- Log in your Tuya IOT Cloud Platform account (<https://iot.tuya.com/>)\
+(In some countries you need to use this url instead: (<https://platform.tuya.com/>)\
+2- Hover on Cloud and select "Cloud Services"\
+![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)\
+3- In the list, find the line that says "Beta APIs" and click the "Free Trial" link\
+![image](https://github.com/user-attachments/assets/40c3f9da-ccd5-4d6a-b8b0-759baa753d47)\
+4- Select "Continue"\
+![image](https://github.com/user-attachments/assets/4d4ac605-b9fa-4aff-8fad-0669a22a7c9b)\
+5- Verify that the "Beta APIs" is activated:\
+![image](https://github.com/user-attachments/assets/9f8514a2-35f2-4b1e-84b7-7ae061420ae2)\
+6- You should now be able to import energy consumption statistics using Xtend Tuya

--- a/docs/configure_go2rtc.md
+++ b/docs/configure_go2rtc.md
@@ -1,31 +1,41 @@
-# Purpose
-The purpose of this documentation is to correctly configure go2rtc to communicate with your Tuya cameras using WebRTC
+# Configure go2rtc
 
-# Prerequisite
-For this, you will need a functionning Tuya IOT Cloud Platform account.<br/>
+## Purpose
+
+The purpose of this documentation is to correctly configure go2rtc to
+communicate with your Tuya cameras using WebRTC
+
+## Prerequisite
+
+For this, you will need a functionning Tuya IOT Cloud Platform account.
 If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md<br/>
-You will also need to have a properly configured Tuya IOT Cloud Platform.<br/>
-Please follow the procedure of https://github.com/azerty9971/xtend_tuya/blob/main/docs/enable_webrtc.md<br/>
-<br/>
-# Steps
-1- Configure a long-lived access token<br/>
-1.1- In your user profile, click the "security" tab and scroll down at the bottom to click the "Create token" button<br/>
-![image](https://github.com/user-attachments/assets/a03f3c61-a27d-4f1f-9c03-d6a9a2063936)<br/>
-1.2- Store the newly created token into a notepad<br/><br/>
-2- Get the device ID of your camera<br/>
-2.1- Find your device in Home Assistant and click the "Download diagnostic" button<br/>
-![image](https://github.com/user-attachments/assets/aecbed92-1006-403b-a993-b3472e64f619)<br/>
-2.2- Open the downloaded file and search for the key "id" of the subnode "data"<br/>
-![image](https://github.com/user-attachments/assets/5527b163-c469-40d7-883a-4a60eafb8b18)<br/>
-2.3- Store this device ID in a notepad<br/><br/>
-3- Configure go2rtc<br/>
-3.1- Add the following lines to your go2rtc configuration:<br/>
-```
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+You will also need to have a properly configured Tuya IOT Cloud Platform.
+Please follow the procedure of <https://github.com/azerty9971/xtend_tuya/blob/main/docs/enable_webrtc.md>
+
+## Steps
+
+1- Configure a long-lived access token
+1.1- In your user profile, click the "security" tab and scroll down at the
+bottom to click the "Create token" button
+![image](https://github.com/user-attachments/assets/a03f3c61-a27d-4f1f-9c03-d6a9a2063936)
+1.2- Store the newly created token into a notepad
+2- Get the device ID of your camera
+2.1- Find your device in Home Assistant and click the "Download diagnostic"
+button
+![image](https://github.com/user-attachments/assets/aecbed92-1006-403b-a993-b3472e64f619)\
+2.2- Open the downloaded file and search for the key "id" of the subnode "data"\
+![image](https://github.com/user-attachments/assets/5527b163-c469-40d7-883a-4a60eafb8b18)\
+2.3- Store this device ID in a notepad\\
+3- Configure go2rtc\
+3.1- Add the following lines to your go2rtc configuration:\
+
+```yaml
 camera_name:
   - webrtc:https://<HA_URL>#format=xtend_tuya#device_id=<DEVICE_ID>#channel=high#auth_token=<AUTH_TOKEN>
 ```
-Replace <HA_URL> by the URL of your home assistant (eg: 192.168.1.12:8123)<br/>
-Replace <DEVICE_ID> by the device ID found in step 2<br/>
-Replace <AUTH_TOKEN> by the long-lived access token found in step 1<br/><br/>
+
+Replace <HA_URL> by the URL of your home assistant (eg: 192.168.1.12:8123)\
+Replace <DEVICE_ID> by the device ID found in step 2\
+Replace <AUTH_TOKEN> by the long-lived access token found in step 1\\
 4- Restart go2rtc and enjoy!

--- a/docs/configure_ir.md
+++ b/docs/configure_ir.md
@@ -1,18 +1,26 @@
-# Purpose
-The purpose of this documentation is to correctly configure your IR devices using the Tuya IOT Cloud platform
+# Configure IR
 
-# Prerequisite
-For this, you will need a functionning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Steps
-1- Log in your Tuya IOT Cloud Platform account (https://iot.tuya.com/)<br/>
-2- Hover on Cloud and select "Cloud Services"<br/>
-![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)<br/>
-3- In the list, find the line that says "IR Control Hub Open Service" and click the "Free Trial" link<br/>
-![image](https://github.com/user-attachments/assets/5d8ae9d2-141e-436f-b459-324663974e91)<br/>
-4- Select "Continue"<br/>
-![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)<br/>
-5- Verify that the "IR Control Hub Open Service" is activated:<br/>
-![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)<br/>
-6- You should now be able to control your IR devices using Xtend Tuya<br/>
+The purpose of this documentation is to correctly configure your IR devices
+using the Tuya IOT Cloud platform
+
+## Prerequisite
+
+For this, you will need a functionning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Steps
+
+1- Log in your Tuya IOT Cloud Platform account (<https://iot.tuya.com/>)\
+2- Hover on Cloud and select "Cloud Services"\
+![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)\
+3- In the list, find the line that says "IR Control Hub Open Service" and click
+the "Free Trial" link\
+![image](https://github.com/user-attachments/assets/5d8ae9d2-141e-436f-b459-324663974e91)\
+4- Select "Continue"\
+![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)\
+5- Verify that the "IR Control Hub Open Service" is activated:\
+![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)\
+6- You should now be able to control your IR devices using Xtend Tuya\

--- a/docs/configure_ir_devices.md
+++ b/docs/configure_ir_devices.md
@@ -1,39 +1,46 @@
-# Purpose
+# Configure IR devices
+
+## Purpose
+
 The purpose of this document is to show how to configure the IR devices in your HA
 
-# Prerequisite
-For this, you will need a functionning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Prerequisite
 
-# Terms used
+For this, you will need a functionning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Terms used
+
 IR Hub: The physical device that sends the IR signals
 IR Remote: The virtual device that is created under the hub to regroup keys that are to be sent to the receiving device
 IR Key: The specific code that should be sent to the receiving device
 
-Think of it like this: the HUB is a pile of remote controls (IR Remote), each remote has multiple buttons (IR Key) 
+Think of it like this: the HUB is a pile of remote controls (IR Remote), each remote has multiple buttons (IR Key)
 
-# Steps to create a new IR Remote
+## Steps to create a new IR Remote
+
 1- Go to the IR HUB device page and click the "Add IR device" button
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/36e33c27-875d-483a-968c-a16600486f8c" />
+![image](https://github.com/user-attachments/assets/36e33c27-875d-483a-968c-a16600486f8c)\
 2- Go to the Integration page, you should see a new discovered device
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/aa4a3c9c-23eb-416c-b910-662074671548" />
+![image](https://github.com/user-attachments/assets/aa4a3c9c-23eb-416c-b910-662074671548)\
 3- Click the "Add button" of the newly discovered device and give the name of your new IR Remote
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/d889ee32-0865-4fb4-800c-942828fdc344" />
+![image](https://github.com/user-attachments/assets/d889ee32-0865-4fb4-800c-942828fdc344)\
 4- Give the IR remote category (if none apply, select DIY)
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/e6861a88-5b5a-43d9-a0ff-7664d6f47c57" />
+![image](https://github.com/user-attachments/assets/e6861a88-5b5a-43d9-a0ff-7664d6f47c57)\
 5- Depending on the IR remote category, you might be asked to provide a brand for the IR Remote
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/9ffb945f-6bf3-4a6a-8466-d2e56715744d" />
+![image](https://github.com/user-attachments/assets/9ffb945f-6bf3-4a6a-8466-d2e56715744d)\
 6- Your new device should be created
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/2169d0aa-e50d-4013-beda-0cee0515ad97" />
+![image](https://github.com/user-attachments/assets/2169d0aa-e50d-4013-beda-0cee0515ad97)\
 
-# Steps to create a new IR Key
+## Steps to create a new IR Key
+
 1- Go to the IR Remote device and click the "Register new IR key" button
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/92eac037-927a-48a3-88ed-d69e5a964612" />
+![image](https://github.com/user-attachments/assets/92eac037-927a-48a3-88ed-d69e5a964612)\
 2- Go to the Integration page, you should see a new discovered device
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/f5fc6059-d510-46fd-958a-112aebafa384" />
+![image](https://github.com/user-attachments/assets/f5fc6059-d510-46fd-958a-112aebafa384)\
 3- _(HAVE THE PHYSICAL REMOTE NEXT TO YOU AND THE HUB BEFORE VALIDATING)_ Click the "Add button" of the newly discovered device, you'll be asked for 2 things: The key display name (Friendly name) and the key technical name (usefull for cards that need a specific key name like Universal IR card)
-<img width="1289" height="886" alt="image" src="https://github.com/user-attachments/assets/8faef4b3-aafe-4405-8481-054fa9c1f021" />
+![image](https://github.com/user-attachments/assets/8faef4b3-aafe-4405-8481-054fa9c1f021)\
 4- Click the "Submit" button then point the remote to the HUB and click the button you want to register (trick, avoid having any magnet such as phone case next to the IR HUB, it prevents the HUB from receiving the signal...)
-<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/d2e3aa49-b48d-4672-9c96-d8c0db74b4b4" />
+![image](https://github.com/user-attachments/assets/d2e3aa49-b48d-4672-9c96-d8c0db74b4b4)\
 5- The new key is now available in your IR Remote
-<img width="1920" height="963" alt="image" src="https://github.com/user-attachments/assets/741c182a-eaf1-4041-b0ce-b42adb18012b" />
+![image](https://github.com/user-attachments/assets/741c182a-eaf1-4041-b0ce-b42adb18012b)\

--- a/docs/configure_locks.md
+++ b/docs/configure_locks.md
@@ -1,19 +1,60 @@
-# Purpose
-The purpose of this documentation is to correctly configure your locks (G30, any other lock) using the Tuya IOT Cloud platform
+# Configure locks
 
-# Prerequisite
-For this, you will need a functioning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Steps
-1- Log in your Tuya IOT Cloud Platform account (https://iot.tuya.com/)<br/>
-2- Hover on Cloud and select "Cloud Services"<br/>
-![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)<br/>
-3- In the list, find the line that says "Smart Lock Open Service" and click the "Free Trial" link<br/>
-![image](https://github.com/user-attachments/assets/5d8ae9d2-141e-436f-b459-324663974e91)<br/>
-4- Select "Continue"<br/>
-![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)<br/>
-5- Verify that the "Smart Lock Open Service" is activated:<br/>
-![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)<br/>
-6- You should now be able to open/close your locks using Xtend Tuya<br/>
+The purpose of this documentation is to correctly configure your locks (G30, any
+other lock) using the Tuya IOT Cloud platform
 
+## Prerequisite
+
+For this, you will need a functioning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Steps
+
+1. Log in your Tuya IOT Cloud Platform account (<https://iot.tuya.com/>)
+2. Hover on Cloud and select "Cloud Services"\
+    ![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)
+3. In the list, find the line that says "Smart Lock Open Service" and click the
+"Free Trial" link\
+    ![image](https://github.com/user-attachments/assets/5d8ae9d2-141e-436f-b459-324663974e91)
+4. Select "Continue"\
+    ![image](https://github.com/user-attachments/assets/2560d24c-d71c-49d5-9d22-00dc1efbc203)
+5. Verify that the "Smart Lock Open Service" is activated:\
+    ![image](https://github.com/user-attachments/assets/bfbb2c03-9a96-4ac3-9f7f-63a35cd4a7a6)
+6. You should now be able to open/close your locks using Xtend Tuya
+
+## Understanding Locking Mechanisms
+
+If your lock does not work with the default settings, you can manually choose a
+locking mechanism in the integration options. Here is how to identify which one
+fits your device based on how it behaves in the official Tuya / Smart Life app:
+
+* **Automatic (Auto):**
+  * *What it does:* Tells the integration to try all methods automatically.
+  * *When to use:* The default option for most locks. Leave it here unless
+    your lock is failing to lock/unlock.
+* **Door operate API:**
+  * *What it does:* Sends a standard lock/unlock command to turn the motor.
+  * *When to use:* Use this if your device is a standard deadbolt/lock that you
+  can lock and unlock directly by tapping a button on the main screen of the
+  Tuya app without any confirmation popups.
+* **Door open API:**
+  * *What it does:* Tells the lock to open the latch immediately.
+  * *When to use:* Use this for simple buzzers, gates, or intercoms that latch
+  open instantly when triggered.
+* **Ticket flow:**
+  * *What it does:* Requests a secure, temporary authorization ticket from Tuya
+  first, then uses it to authenticate the unlock request (mimics a secure
+  passcode handshake).
+  * *When to use:* Use this if your lock requires secure remote verification.
+  This is very common for locks that require someone to press the doorbell first
+  to "wake it up" and authorize a remote unlock within a short window of time,
+  or if the Tuya app asks for a password, fingerprint, or confirmation dialog
+  before letting you unlock it remotely.
+* **DPCode command:**
+  * *What it does:* Bypasses standard lock protocols and sends a raw function
+  command (datapoint) directly to the device.
+  * *When to use:* Best for custom relays, DIY smart locks, or non-standard
+  controllers that behave like a switch rather than an official lock.

--- a/docs/enable_all_dpcodes.md
+++ b/docs/enable_all_dpcodes.md
@@ -1,24 +1,33 @@
-# Purpose
-The purpose of this documentation is to expose all the functionnalities of your devices to Xtend Tuya.
+# Enable all DP codes
 
-# Prerequisite
-For this, you will need a functioning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Steps
-1- Connect to your Tuya IOT Cloud Platform account (https://iot.tuya.com)<br/>
-2- On the left, hover over Cloud then select Development:<br/>
-![image](https://github.com/user-attachments/assets/daab8f84-20d6-4acc-8809-feec9c63113a)<br/>
-3- Click the "Open Project"<br/>
-![image](https://github.com/user-attachments/assets/9244657e-a1aa-4bd2-8fe2-e5b0c12a1eaf)<br/>
-4- Go to the "Devices" tab:<br/>
-![image](https://github.com/user-attachments/assets/270330ee-5575-4afc-8b06-a4c34c7129af)<br/>
-5- Click the "3 dots" on the right of the page (bottom right in the next screenshot):<br/>
-![image](https://github.com/user-attachments/assets/3adf6731-b4e2-4971-850f-380ab9bf656c)<br/>
-6- On the panel that opens, hover over a device category and click the "pencil" icon:<br/>
-![image](https://github.com/user-attachments/assets/04d723ad-8fb1-4c71-8999-e800ed2c756d)<br/>
-7- In the new window, select the box "DP Instruction" and then click "Save configuration"<br/>
-![image](https://github.com/user-attachments/assets/b8571a23-cecc-4561-9b90-e85dc76571b1)<br/>
-8- Repeat step 5 to 7 for each device category<br/>
-9- Restart HA or reload Xtend Tuya<br/>
+The purpose of this documentation is to expose all the functionnalities of your
+devices to Xtend Tuya.
+
+## Prerequisite
+
+For this, you will need a functioning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Steps
+
+1- Connect to your Tuya IOT Cloud Platform account (<https://iot.tuya.com>)\
+2- On the left, hover over Cloud then select Development:\
+![image](https://github.com/user-attachments/assets/daab8f84-20d6-4acc-8809-feec9c63113a)\
+3- Click the "Open Project"\
+![image](https://github.com/user-attachments/assets/9244657e-a1aa-4bd2-8fe2-e5b0c12a1eaf)\
+4- Go to the "Devices" tab:\
+![image](https://github.com/user-attachments/assets/270330ee-5575-4afc-8b06-a4c34c7129af)\
+5- Click the "3 dots" on the right of the page (bottom right in the next screenshot):\
+![image](https://github.com/user-attachments/assets/3adf6731-b4e2-4971-850f-380ab9bf656c)\
+6- On the panel that opens, hover over a device category and click the "pencil"
+icon:\
+![image](https://github.com/user-attachments/assets/04d723ad-8fb1-4c71-8999-e800ed2c756d)\
+7- In the new window, select the box "DP Instruction" and then click "Save
+configuration"\
+![image](https://github.com/user-attachments/assets/b8571a23-cecc-4561-9b90-e85dc76571b1)\
+8- Repeat step 5 to 7 for each device category\
+9- Restart HA or reload Xtend Tuya\
 10- Enjoy!

--- a/docs/enable_webrtc.md
+++ b/docs/enable_webrtc.md
@@ -1,17 +1,25 @@
-# Purpose
-The purpose of this documentation is to correctly configure your IOT cloud account to handle WebRTC streams that you will then consume using go2rtc
+# Enable WebRTC
 
-# Prerequisite
-For this, you will need a functionning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Steps
-1- Log in your Tuya IOT Cloud Platform account (https://iot.tuya.com/)<br/>
-2- Hover on Cloud and select "Cloud Services"<br/>
-![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)<br/>
-3- In the list, find the line that says "IoT Video Live Stream" and click the "Free Trial" link<br/>
-![image](https://github.com/user-attachments/assets/1320b71d-17ff-44c1-bbe0-016541b9b0f9)<br/>
-4- Select "Continue"<br/>
-![image](https://github.com/user-attachments/assets/61ffbae2-6978-42a9-a396-41a9bc5818f8)<br/>
-5- Verify that the "IoT Video Live Stream" is activated:<br/>
-![image](https://github.com/user-attachments/assets/cd58e04d-632d-4e32-8d17-b5447480cb92)<br/>
+The purpose of this documentation is to correctly configure your IOT cloud
+account to handle WebRTC streams that you will then consume using go2rtc
+
+## Prerequisite
+
+For this, you will need a functionning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Steps
+
+1- Log in your Tuya IOT Cloud Platform account (<https://iot.tuya.com/>)\
+2- Hover on Cloud and select "Cloud Services"\
+![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)\
+3- In the list, find the line that says "IoT Video Live Stream" and click the
+"Free Trial" link\
+![image](https://github.com/user-attachments/assets/1320b71d-17ff-44c1-bbe0-016541b9b0f9)\
+4- Select "Continue"\
+![image](https://github.com/user-attachments/assets/61ffbae2-6978-42a9-a396-41a9bc5818f8)\
+5- Verify that the "IoT Video Live Stream" is activated:\
+![image](https://github.com/user-attachments/assets/cd58e04d-632d-4e32-8d17-b5447480cb92)

--- a/docs/renew_cloud_credentials.md
+++ b/docs/renew_cloud_credentials.md
@@ -1,35 +1,49 @@
-# Purpose
-The purpose of this document is to show how to extend the trial period of your cloud credential account
+# Renew cloud credentials
 
-# Prerequisite
-For this, you will need a functionning Tuya IOT Cloud Platform account. If you don't have one already please follow the following guide:
-https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
+## Purpose
 
-# Quickfix
-1- Go to the following [URL](https://platform.tuya.com/cloud/products/detail?abilityId=1442730014117204014&abilityAuth=0&tab=1) and log into your Tuya IOT Cloud Platform account
+The purpose of this document is to show how to extend the trial period of your
+cloud credential account
+
+## Prerequisite
+
+For this, you will need a functionning Tuya IOT Cloud Platform account. If you
+don't have one already please follow the following guide:
+<https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md>
+
+## Quickfix
+
+1- Go to the following
+[URL](https://platform.tuya.com/cloud/products/detail?abilityId=1442730014117204014&abilityAuth=0&tab=1)
+and log into your Tuya IOT Cloud Platform account\
 2- Click on "Extend Trial Period"
-<img width="1778" height="408" alt="image" src="https://github.com/user-attachments/assets/ade6d91d-8e3f-474a-af17-9af0b0780a3b" />
+![image](https://github.com/user-attachments/assets/ade6d91d-8e3f-474a-af17-9af0b0780a3b)\
 3- Fill in the required fields and submit
 ![image](https://github.com/user-attachments/assets/12ad4c91-163b-40b8-b8f9-d91a3d58cb8f)
-4- Once done, the application has to be reviewed by Tuya (this is usually very quick, like less than 10 minutes)<br/>
+4- Once done, the application has to be reviewed by Tuya (this is usually very
+quick, like less than 10 minutes)\
 ![image](https://github.com/user-attachments/assets/2e467223-85f8-441a-a696-bd303e4546f0)
-5- Every few minutes, refresh the page and wait for this<br/>
+5- Every few minutes, refresh the page and wait for this\
 ![image](https://github.com/user-attachments/assets/75ff334d-3412-4a03-a511-566d0aa58e42)
 6- Restart your Home Assistant and enjoy!
 
-# More detailed steps
-1- Log in your Tuya IOT Cloud Platform account (https://iot.tuya.com/)<br/>
-2- Hover on Cloud and select "Cloud Services"<br/>
-![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)<br/>
-3- In the list, verify that the status of "IoT Core" is "Alerting", if it's not then you probably don't need to perform the current steps<br/>
-![image](https://github.com/user-attachments/assets/0ee8f9ab-c112-49a4-8377-08d5e1f86fd3)<br/>
-4- If the status is "Alerting", click the "View Details" link (as in screenshot above)<br/>
-5- Now click the "Extend Trial Period" button:<br/>
-![image](https://github.com/user-attachments/assets/d4a147d5-edf5-4143-b63b-6dd2b1ed277a)<br/>
-6- Now fill in all the required fields and submit<br/>
+## More detailed steps
+
+1- Log in your Tuya IOT Cloud Platform account (<https://iot.tuya.com/>)\
+2- Hover on Cloud and select "Cloud Services"\
+![image](https://github.com/user-attachments/assets/80d90a6a-f337-417c-9c22-6f298799b803)\
+3- In the list, verify that the status of "IoT Core" is "Alerting", if it's not
+then you probably don't need to perform the current steps\
+![image](https://github.com/user-attachments/assets/0ee8f9ab-c112-49a4-8377-08d5e1f86fd3)\
+4- If the status is "Alerting", click the "View Details" link (as in screenshot
+above)\
+5- Now click the "Extend Trial Period" button:
+![image](https://github.com/user-attachments/assets/d4a147d5-edf5-4143-b63b-6dd2b1ed277a)\
+6- Now fill in all the required fields and submit\
 ![image](https://github.com/user-attachments/assets/12ad4c91-163b-40b8-b8f9-d91a3d58cb8f)
-7- Once done, the application has to be reviewed by Tuya (this is usually very quick, like less than 10 minutes)<br/>
+7- Once done, the application has to be reviewed by Tuya (this is usually very
+quick, like less than 10 minutes)\
 ![image](https://github.com/user-attachments/assets/2e467223-85f8-441a-a696-bd303e4546f0)
-8- Every few minutes, refresh the page and wait for this<br/>
+8- Every few minutes, refresh the page and wait for this\
 ![image](https://github.com/user-attachments/assets/75ff334d-3412-4a03-a511-566d0aa58e42)
 9- Restart your Home Assistant and enjoy!


### PR DESCRIPTION
## Summary

This PR adds dedicated support for the **Ticket flow** unlock method (`TICKET_FLOW`) in `xtend_tuya` smart lock integration, particularly targeting doorbell/video smart locks.

### Technical Motivation

1. **Standard `door_operate` limitation**:
   - Executes `self.get_supported_unlock_types(device, api)` to check reported unlock modes before attempting to open.
   - Requires a string payload (`open: str`) representing specific unlock types (e.g., `"1"` or `"beacon"`).
   - **Failure case**: Video/doorbell locks operating within a temporary doorbell wake-up window (or locks that do not declare static `supported_unlock_types` in Tuya Cloud) fail this check and return `False`.

2. **`Ticket flow` (`_lock_unlock_command_ticket_flow`) solution**:
   - Requests a password ticket via `/v1.0/devices/{device.id}/door-lock/password-ticket`.
   - **Bypasses `get_supported_unlock_types` validation** and passes a boolean `open: True` to `call_door_operate`.
   - Directly executes `/v1.0/smart-lock/devices/{id}/password-free/door-operate` with `{"ticket_id": ticket_id, "open": True}`.

---

### Changes Included
- **feat(locks)**: Added `TICKET_FLOW` to `XTLockingMechanism` enum and implemented `_lock_unlock_command_ticket_flow`.
- **docs(locks)**: Updated `configure_locks.md` documenting all available locking mechanisms (Auto, Door operate API, Door open API, Ticket flow API, DPCode command).
- **docs**: Fixed markdown linting errors across documentation files.
- **chore**: Added `.markdownlint.json` configuration file.