### PR TITLE
Keep cumulative energy available while devices are offline

### DIFF
--- a/custom_components/xtend_tuya/sensor.py
+++ b/custom_components/xtend_tuya/sensor.py
@@ -2360,14 +2360,33 @@ class XTSensorEntity(XTEntity, TuyaSensorEntity, RestoreSensor):  # type: ignore
 
     @property
     def available(self) -> bool:  # type: ignore[override]
-        """Return True for devices that must be treated as always-online."""
+        """Return whether this sensor has a usable value."""
         if (
             self.device.id in FORCE_ALWAYS_ONLINE_BY_DEVICE_ID
             or self.device.product_id in FORCE_ALWAYS_ONLINE_BY_PID
             or self.device.category in FORCE_ALWAYS_ONLINE_BY_CATEGORY
         ):
             return True
-        return self.device.online
+        if self.device.online:
+            return True
+
+        # A cumulative energy value remains valid while its device is offline.
+        # Keeping the last known/restored value available lets the recorder and
+        # Energy dashboard continue using the statistic without pretending that
+        # instantaneous measurements (such as power) are current.
+        if (
+            self.entity_description.restoredata
+            and self.entity_description.device_class is SensorDeviceClass.ENERGY
+            and self._attr_state_class
+            in (SensorStateClass.TOTAL, SensorStateClass.TOTAL_INCREASING)
+        ):
+            dpcode = getattr(self._dpcode_wrapper, "dpcode", None)
+            return (
+                dpcode is not None
+                and (dpcode in self.device.status or self._restored_data is not None)
+            )
+
+        return False
 
     def reset_value(self, _: datetime | None, manual_call: bool = False) -> None:
         if manual_call and self.cancel_reset_after_x_seconds is not None:

--- a/docs/configure_energy_sensor_statistics.md
+++ b/docs/configure_energy_sensor_statistics.md
@@ -17,3 +17,28 @@ https://github.com/azerty9971/xtend_tuya/blob/main/docs/cloud_credentials.md
 <img width="1810" height="660" alt="image" src="https://github.com/user-attachments/assets/9f8514a2-35f2-4b1e-84b7-7ae061420ae2" /><br/>
 6- You should now be able to import energy consumption statistics using Xtend Tuya<br/>
 
+## Power and energy values
+
+Smart plugs commonly expose two different kinds of measurements:
+
+- **Power** is the instantaneous load in W. An online plug that is switched off
+  should normally report `0 W`. If the plug itself is offline, the power sensor
+  is unavailable because there is no current measurement.
+- **Consumption/energy** is a cumulative counter in kWh. It does not return to
+  zero when the plug is switched off. Home Assistant calculates the energy used
+  during a selected period from changes in this counter.
+
+Use a cumulative Consumption or Total energy entity as an individual device in
+Home Assistant's Energy dashboard. Do not use the Power entity there.
+
+Xtend Tuya retains the last known cumulative energy value while a device is
+offline. This is safe because the value is a total rather than a live
+measurement; it also prevents temporary connectivity loss from making the
+Energy dashboard statistic unavailable. Instantaneous Power, Current, and
+Voltage entities remain unavailable until the device reconnects.
+
+If a switch has no Power, Current, Voltage, Consumption, or Total energy entity,
+download its Xtend Tuya device diagnostics and check whether the device exposes
+the corresponding datapoints. Many wall switches and inexpensive USB relay
+modules do not contain metering hardware, so the integration cannot derive
+electricity usage for them.


### PR DESCRIPTION
## Summary

- keep restored cumulative energy sensors available at their last known value when a device is cloud-offline
- leave instantaneous measurements such as power, current, and voltage unavailable while the device cannot report live data
- document the difference between instantaneous power and cumulative energy, Energy dashboard selection, and devices without metering datapoints

## Why

`XTSensorEntity.available` currently follows `device.online` for every sensor. The consumption descriptors are restore-enabled `total`/`total_increasing` energy counters, so their last known value remains valid while the device is unreachable. Marking those counters unavailable interrupts their recorder statistics and causes Energy dashboard validation errors, even though Xtend Tuya has already restored a usable cumulative value.

The exception is deliberately limited to restore-enabled cumulative energy sensors with either a current DP value or restored sensor data. Live measurements continue to reflect device availability.

## Validation

- `git diff --check`
- compiled the changed module with the Python runtime in Home Assistant Container
- deployed against Home Assistant with Xtend Tuya 4.5.1
- verified seven cloud-offline plugs retained their cumulative kWh values after restart
- verified their instantaneous power sensors remained unavailable
- verified online, switched-off plugs still reported `0 W` while retaining their lifetime kWh counters
- verified Energy dashboard validation no longer reported `entity_unavailable` for these cumulative sensors

The repository has no built-in test framework, so validation used a live Home Assistant instance as described in the project instructions.