### PR TITLE
Handle options flow when runtime data is unavailable

### DIFF
--- a/custom_components/xtend_tuya/config_flow.py
+++ b/custom_components/xtend_tuya/config_flow.py
@@ -358,10 +358,9 @@ class TuyaOptionFlow(OptionsFlow):
         self.selected_device_id: str | None = None
         self.selected_device_next_step_id: str | None = None
         self._device_options: dict[str, str] = {}
-        self.multi_manager: mm.MultiManager | None = (
-            getattr(config_entry.runtime_data, "multi_manager")
-            if config_entry.runtime_data
-            else None
+        runtime_data = getattr(config_entry, "runtime_data", None)
+        self.multi_manager: mm.MultiManager | None = getattr(
+            runtime_data, "multi_manager", None
         )
         if config_entry.options is not None:
             self.options = config_entry.options


### PR DESCRIPTION
## Summary

- avoid dereferencing ConfigEntry.runtime_data before checking whether it exists
- allow the options/API-credential flow to open while an entry is unloaded or in setup_retry
- keep device-specific options disabled naturally when no MultiManager is available

## Reproduction

When authentication fails, the entry enters setup_retry before async_setup_entry assigns runtime_data. Opening Configure then crashes in TuyaOptionFlow.__init__ with:

    AttributeError: 'ConfigEntry' object has no attribute 'runtime_data'

## Validation

- Python compileall passes
- reproduced against Home Assistant 2026.7.2
- the options-flow endpoint now returns HTTP 200 and the configure_api form with the entry still in setup_retry
- deployed to the affected installation and confirmed Home Assistant remains healthy