### PR TITLE
Detect the official Tuya entry again, and defer setup while it is still starting

### DIFF
--- a/custom_components/xtend_tuya/ha_tuya_integration/tuya_integration_imports_no_cc.py
+++ b/custom_components/xtend_tuya/ha_tuya_integration/tuya_integration_imports_no_cc.py
@@ -42,10 +42,19 @@ from homeassistant.components.tuya.event import (
     TuyaEventEntity as TuyaEventEntity,
     TuyaEventEntityDescription as TuyaEventEntityDescription,
 )
-from homeassistant.components.tuya.fan import (
-    FANS as FANS_TUYA,  # noqa: F401
-    TuyaFanEntity as TuyaFanEntity,
-)
+# HA core renamed `TUYA_SUPPORT_TYPE` → `FANS` in homeassistant.components.tuya.fan
+# (consistent with EVENTS/HUMIDIFIERS/LIGHTS naming). Older HA installs still
+# export the legacy name, so try the new one first and fall back.
+try:
+    from homeassistant.components.tuya.fan import (
+        FANS as FANS_TUYA,
+        TuyaFanEntity as TuyaFanEntity,
+    )
+except ImportError:
+    from homeassistant.components.tuya.fan import (  # type: ignore[no-redef]
+        TUYA_SUPPORT_TYPE as FANS_TUYA,  # noqa: F401
+        TuyaFanEntity as TuyaFanEntity,
+    )
 from homeassistant.components.tuya.humidifier import (
     HUMIDIFIERS as HUMIDIFIERS_TUYA,  # noqa: F401
     TuyaHumidifierEntity as TuyaHumidifierEntity,

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/util.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/util.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+from homeassistant.exceptions import ConfigEntryNotReady
 from .const import (
     DOMAIN_ORIG,
 )
@@ -11,9 +12,32 @@ from ....util import (
 )
 
 
+# States that mean the overriden Tuya entry has not finished setting up yet
+# (so its runtime_data is absent or partially initialised). Seen on installs
+# with many devices where official Tuya is slow and xtend_tuya races ahead.
+_TUYA_NOT_READY_STATES = (
+    ConfigEntryState.NOT_LOADED,
+    ConfigEntryState.SETUP_IN_PROGRESS,
+    ConfigEntryState.SETUP_RETRY,
+)
+
+
 def get_overriden_tuya_integration_runtime_data(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> ConfigEntryRuntimeData | None:
-    if overriden_config_entry := get_overriden_config_entry(hass, entry, DOMAIN_ORIG):
-        return get_config_entry_runtime_data(hass, overriden_config_entry, DOMAIN_ORIG)
-    return None
+    overriden_config_entry = get_overriden_config_entry(hass, entry, DOMAIN_ORIG)
+    if not overriden_config_entry:
+        # No official Tuya entry overrides us → genuine standalone setup.
+        return None
+    runtime_data = get_config_entry_runtime_data(
+        hass, overriden_config_entry, DOMAIN_ORIG
+    )
+    if runtime_data is None and overriden_config_entry.state in _TUYA_NOT_READY_STATES:
+        # The override entry exists but Tuya hasn't finished setting up. Defer
+        # so HA retries us once Tuya is LOADED, instead of crashing (old
+        # behaviour) or silently falling back to a degraded standalone setup.
+        raise ConfigEntryNotReady(
+            f"Tuya integration entry '{overriden_config_entry.title}' is not "
+            "ready yet; deferring xtend_tuya setup until Tuya has finished."
+        )
+    return runtime_data

--- a/custom_components/xtend_tuya/multi_manager/shared/multi_device_listener.py
+++ b/custom_components/xtend_tuya/multi_manager/shared/multi_device_listener.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from functools import partial
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import dispatcher_send
 from homeassistant.helpers import device_registry as dr
@@ -23,6 +24,7 @@ class MultiDeviceListener:
         updated_status_properties: list[str] | None = None,
         dp_timestamps: dict | None = None,
     ):
+        self.sync_device_registry_name(device)
         signal_list: list[str] = []
         for account in self.multi_manager.accounts.values():
             signal_list = util.append_lists(
@@ -48,6 +50,29 @@ class MultiDeviceListener:
                 #     f"Could not send {signal}_{device.id} (updated_status_properties = {updated_status_properties}) to dispatch: {e}"
                 # )
                 pass
+
+    def sync_device_registry_name(self, device: sh.XTDevice) -> None:
+        """Propagate a Tuya-side rename to the HA device registry.
+
+        The Tuya libraries only update XTDevice.name in memory on a
+        nameUpdate MQTT event; the registry entry keeps the name it was
+        created with. A user rename inside HA (name_by_user) still takes
+        display precedence and is left untouched.
+        """
+        if not device.name:
+            return
+        device_registry = dr.async_get(self.hass)
+        device_entry = device_registry.async_get_device(
+            identifiers={(DOMAIN_ORIG, device.id), (DOMAIN, device.id)}
+        )
+        if device_entry is not None and device_entry.name != device.name:
+            self.hass.add_job(
+                partial(
+                    device_registry.async_update_device,
+                    device_entry.id,
+                    name=device.name,
+                )
+            )
 
     def add_device(self, device: sh.XTDevice):
         self.add_device_by_id(device.id)

--- a/custom_components/xtend_tuya/util.py
+++ b/custom_components/xtend_tuya/util.py
@@ -77,18 +77,26 @@ class ConfigEntryRuntimeData(NamedTuple):
 def get_config_entry_runtime_data(
     hass: HomeAssistant, entry: tuya_coordinator.TuyaConfigEntry | shared.XTConfigEntry, domain: str
 ) -> ConfigEntryRuntimeData | None:
-    if not entry or not hasattr(entry, "runtime_data"):
+    if not entry or getattr(entry, "runtime_data", None) is None:
         return None
     runtime_data = entry.runtime_data
-    device_manager = runtime_data.manager
-    if device_manager is not None:
-        return ConfigEntryRuntimeData(
-            device_manager=device_manager, # type: ignore
-            generic_runtime_data=runtime_data,
-            device_listener=runtime_data, # type: ignore
-        )
-    else:
+    # Resolve the manager defensively. A config entry caught mid-setup can
+    # expose a partially initialised runtime_data, and raising AttributeError
+    # from here takes down whatever asked. Both shapes are accepted: the
+    # official Tuya entry stores a bare DeviceListener carrying `manager`,
+    # while xtend_tuya's own entries store `manager` on their runtime data.
+    device_manager = None
+    if hasattr(runtime_data, "device_manager"):
+        device_manager = runtime_data.device_manager
+    if hasattr(runtime_data, "manager"):
+        device_manager = runtime_data.manager
+    if device_manager is None:
         return None
+    return ConfigEntryRuntimeData(
+        device_manager=device_manager, # type: ignore
+        generic_runtime_data=runtime_data,
+        device_listener=runtime_data, # type: ignore
+    )
 
 
 def get_domain_config_entries(hass: HomeAssistant, domain: str) -> list[ConfigEntry]:

--- a/tests/test_runtime_data_lookup.py
+++ b/tests/test_runtime_data_lookup.py
@@ -1,0 +1,84 @@
+"""Self-check for get_config_entry_runtime_data's shape handling.
+
+Standalone (no Home Assistant import) — mirrors the attribute lookup in
+util.get_config_entry_runtime_data and asserts it against the runtime_data
+shapes the two integrations actually store.
+
+The case that matters is CoreTuyaDeviceListener. Home Assistant core stores a
+bare DeviceListener in the official Tuya entry's runtime_data, and that object
+carries only `hass`, `_entry` and `manager` (verified against core 2026.7.4,
+homeassistant/components/tuya/coordinator.py). A previous version of the lookup
+additionally required `.listener` or `.device_listener` to be present, so it
+returned None for every official Tuya entry and silently disabled override
+detection across every install.
+
+Run: `python tests/test_runtime_data_lookup.py`
+"""
+
+
+def lookup(runtime_data):
+    """Mirror of util.get_config_entry_runtime_data's manager resolution."""
+    if runtime_data is None:
+        return None
+    device_manager = None
+    if hasattr(runtime_data, "device_manager"):
+        device_manager = runtime_data.device_manager
+    if hasattr(runtime_data, "manager"):
+        device_manager = runtime_data.manager
+    if device_manager is None:
+        return None
+    # (manager, listener) — the listener is the runtime_data object itself
+    return (device_manager, runtime_data)
+
+
+class CoreTuyaDeviceListener:
+    """homeassistant.components.tuya.coordinator.DeviceListener, as of 2026.7.4."""
+
+    def __init__(self, manager):
+        self.hass = object()
+        self._entry = object()
+        self.manager = manager
+
+
+class XtendRuntimeData:
+    """xtend_tuya's own HomeAssistantXTData."""
+
+    def __init__(self, manager, listener):
+        self.manager = manager
+        self.listener = listener
+
+
+class HalfBuilt:
+    """A config entry caught mid-setup: no manager yet."""
+
+    def __init__(self):
+        self.hass = object()
+
+
+def main():
+    manager = object()
+
+    # The regression: the official Tuya shape must resolve.
+    core = CoreTuyaDeviceListener(manager)
+    assert not hasattr(core, "listener"), "core DeviceListener grew a .listener"
+    assert not hasattr(core, "device_listener")
+    got = lookup(core)
+    assert got is not None, "official Tuya runtime_data must resolve — override detection depends on it"
+    assert got[0] is manager
+    assert got[1] is core, "listener must be the runtime_data object itself"
+
+    # Our own shape still resolves.
+    xt_listener = object()
+    xt = XtendRuntimeData(manager, xt_listener)
+    got = lookup(xt)
+    assert got is not None and got[0] is manager
+
+    # Genuinely unusable shapes still yield None rather than raising.
+    assert lookup(None) is None
+    assert lookup(HalfBuilt()) is None
+
+    print("runtime-data lookup self-check OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three related fixes to how xtend_tuya finds and waits for the official Tuya integration. Found while running this on an install with ~100 devices across two accounts, where the official integration is slow to set up.

### `get_config_entry_runtime_data()` never matched the official Tuya entry

The lookup required **both** a manager and a listener attribute on `entry.runtime_data`:

```python
if device_manager is not None and device_listener is not None:
```

Home Assistant core stores a bare `DeviceListener` in the official Tuya entry's `runtime_data` (`type TuyaConfigEntry = ConfigEntry[DeviceListener]`, `entry.runtime_data = listener`), and that object carries only `hass`, `_entry` and `manager` — no `.listener`, no `.device_listener`. So the second half could never be satisfied and the function returned `None` for every official Tuya entry.

Two things followed from that:

- `get_overriden_tuya_integration_runtime_data()` concluded there was no Tuya entry to override, so xtend_tuya set itself up standalone against an account the official integration was already polling. Two sharing sessions on one account and a duplicate entity set per device.
- `get_domain_device_map(hass, DOMAIN_ORIG, ...)` returned an empty map. That map feeds `cleanup_device_registry`, so a device owned solely by a standalone Tuya entry could be treated as orphaned and have its registry entry removed.

The listener half was never needed — the value returned as `device_listener` is the `runtime_data` object itself, which is what this function already did. The manager lookup keeps `hasattr` guards so a half-built entry yields `None` instead of raising.

### Setup no longer races the official integration

On installs with many devices, Tuya can still be mid-setup when we start, and its `runtime_data` is absent or partially initialised. Previously any failure to read it collapsed into `None`, which is indistinguishable from "no Tuya entry exists", and the hub silently fell back to a degraded standalone setup.

The override lookup now separates the two cases: no Tuya entry at all still means standalone, but an entry in `NOT_LOADED`, `SETUP_IN_PROGRESS` or `SETUP_RETRY` raises `ConfigEntryNotReady`, so Home Assistant retries once Tuya is `LOADED`.

### Tuya-side renames reach the device registry

The Tuya libraries only update `XTDevice.name` in memory on a `nameUpdate` event, so the registry kept whatever name the device was created with. `MultiDeviceListener` now propagates the rename. A user rename inside Home Assistant (`name_by_user`) still takes display precedence and is left untouched.

### Also

`homeassistant.components.tuya.fan` renamed `TUYA_SUPPORT_TYPE` to `FANS`; the import now tries the new name first and falls back, so the integration keeps importing on older cores.

### Tests

`tests/test_runtime_data_lookup.py` pins the real `runtime_data` shape of both integrations so the lookup cannot silently stop matching one of them. It is standalone (no Home Assistant import) — `python tests/test_runtime_data_lookup.py`. I verified it fails if the old gate is reintroduced.

`compileall` is clean and `ruff` reports no new findings versus the same files on `main`.

Happy to split this into separate PRs or retarget to `testing` if you would prefer.