### PR TITLE
Add support for the fdm5kw irrigation valve (QT-08W / QT-08W-T3)

### DIFF
--- a/custom_components/xtend_tuya/__init__.py
+++ b/custom_components/xtend_tuya/__init__.py
@@ -255,6 +255,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: XTConfigEntry) -> bool:
         None,
         False,
     )
+
+    # Build the fdm5kw valve home/room map for this hub up front, decoupled
+    # from entity spawn. Doing it lazily from a timer-registry entity meant
+    # that any hub whose valves fell back to the bare "Valve" entity never
+    # triggered the walk, leaving that whole hub without home/room names.
+    # Each hub's token_info.uid is its own linked SmartLife account, so
+    # walking per hub unions every account's homes into the shared
+    # LOCATION_MAP. Fire-and-forget and fully guarded: fetching locations
+    # must never block or break setup.
+    try:
+        from .entity_parser.fdm5kw import location_service as _fdm5kw_location
+
+        hass.async_create_task(
+            _fdm5kw_location.async_ensure_scheduled(hass, multi_manager)
+        )
+    except Exception:  # noqa: BLE001
+        LOGGER.debug("fdm5kw: location bootstrap scheduling failed", exc_info=True)
     multi_manager.device_watcher.report_message(
         XTDeviceWatcherSpecialDevice.NOT_LINKED_TO_A_DEVICE,
         f"Xtended Tuya {entry.title} loaded in {datetime.now() - start_time}",

--- a/custom_components/xtend_tuya/config_flow.py
+++ b/custom_components/xtend_tuya/config_flow.py
@@ -358,9 +358,12 @@ class TuyaOptionFlow(OptionsFlow):
         self.selected_device_id: str | None = None
         self.selected_device_next_step_id: str | None = None
         self._device_options: dict[str, str] = {}
+        # runtime_data only exists while the entry is loaded; opening the
+        # options flow on an entry in error / not-loaded state (or mid-removal)
+        # otherwise raises AttributeError and the whole flow 500s.
         runtime_data = getattr(config_entry, "runtime_data", None)
-        self.multi_manager: mm.MultiManager | None = getattr(
-            runtime_data, "multi_manager", None
+        self.multi_manager: mm.MultiManager | None = (
+            getattr(runtime_data, "multi_manager", None) if runtime_data else None
         )
         if config_entry.options is not None:
             self.options = config_entry.options

--- a/custom_components/xtend_tuya/entity_parser/fdm5kw/const.py
+++ b/custom_components/xtend_tuya/entity_parser/fdm5kw/const.py
@@ -1,0 +1,25 @@
+"""Constants for fdm5kw irrigation valve entity parser."""
+
+from __future__ import annotations
+
+# Tuya device category for this valve controller
+DEVICE_CATEGORY = "sfkzq"
+
+# Product ID for the fdm5kw irrigation valve
+PRODUCT_ID = "o6dagifntoafakst"
+
+# Days of week bitmask mapping (for time_task decoding)
+DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+
+# Tuya OpenAPI error: controllable-device pool quota exceeded. Empirically
+# validated 2026-05-13 against a live fdm5kw fleet; not in Tuya's public
+# docs. Returned on cloud-timer POST when the account's device count is
+# above the plan limit. Treat as a soft failure with a persistent
+# notification, not an exception.
+TUYA_ERR_DEVICE_POOL_QUOTA = 60001001
+TUYA_ERR_DEVICE_POOL_QUOTA_MSG = (
+    "Tuya controllable-device quota exceeded. Cloud-side timer write was "
+    "rejected; the on-device timer DP was still saved and will fire "
+    "locally. To re-enable cloud sync (and SmartLife schedule edits), "
+    "upgrade the IoT-Core plan or remove unused devices from the project."
+)

--- a/custom_components/xtend_tuya/entity_parser/fdm5kw/control_service.py
+++ b/custom_components/xtend_tuya/entity_parser/fdm5kw/control_service.py
@@ -1,0 +1,218 @@
+"""Single-watering (one_control) services for fdm5kw irrigation valve.
+
+The one_control DP is a 6-byte payload:
+
+    [mode, value(4 bytes uint32 BE), flag]
+
+Modes:
+    0 = idle (stops a running cycle)
+    1 = duration  (value = seconds)
+    3 = volume    (value = liters)
+
+Byte 5 ("flag") is not yet fully understood; observed state writes use
+zero, which matches what the device pushes back when idle. We use zero
+for both writes; if the firmware needs a non-zero trigger we can revisit
+once we have a captured packet from SmartLife in active mode.
+
+This is the proper fix for the "duration ignored on second start" bug:
+the existing valve switch + duration number entity decouples target from
+trigger, so the device may use a stale value. Writing one_control directly
+sends mode + value + start atomically.
+"""
+
+from __future__ import annotations
+
+import base64
+import logging
+
+from ...multi_manager.multi_manager import MultiManager
+from ...multi_manager.shared.threading import XTEventLoopProtector
+from ...util import get_all_multi_managers
+
+_LOGGER = logging.getLogger(__name__)
+
+ONE_CONTROL_CODE = "one_control"
+SWITCH_CODE = "switch"
+
+# QT-08W-T3 valves have no `one_control` DP. Their manual single-run is the
+# `cyc_control_0` DP, captured live 2026-07-15 (706 toggled on/off in SmartLife):
+#     start = 00 00 00 00 00 3c 01 00 00 01   (value=60 s, flag byte[9]=1)
+#     stop  = 00 00 00 00 00 3c 01 00 00 00   (flag byte[9]=0)
+# Layout: [00, 00, value(4B BE), 01, 00, 00, flag]. byte[6]=01 = duration mode.
+# The device runs `value` seconds then hardware-closes (counter_custom logged the
+# actual run when stopped early), same offline-safe model as one_control.
+CYC_CONTROL_CODE = "cyc_control_0"
+
+
+def build_cyc_control_payload(value: int, flag: int) -> str:
+    """Build base64 10-byte cyc_control_0 payload [00,00,value(4B BE),01,00,00,flag]."""
+    if not 0 <= value <= 0xFFFFFFFF:
+        raise ValueError(f"value out of range: {value}")
+    payload = bytes(
+        [
+            0,
+            0,
+            (value >> 24) & 0xFF,
+            (value >> 16) & 0xFF,
+            (value >> 8) & 0xFF,
+            value & 0xFF,
+            1,
+            0,
+            0,
+            flag & 0xFF,
+        ]
+    )
+    return base64.b64encode(payload).decode("ascii")
+
+
+def _is_t3(multi_manager: MultiManager, device_id: str) -> bool:
+    """T3 valve = carries the `cyc_control_0` DP (no `one_control`)."""
+    device = multi_manager.device_map.get(device_id)
+    return device is not None and device.status.get(CYC_CONTROL_CODE) is not None
+
+# one_control is a 6-byte payload: [lead, value(4-byte uint32 BE), flag].
+#
+# These leading-byte / flag values are NOT guesses — they were captured from
+# the SmartLife app's own "single watering" command against FF East 10 (920)
+# on 2026-06-08 via the Tuya device command log (event type 5):
+#
+#     one_control = AAAAAB4B  ->  bytes [0x00, 0x00,0x00,0x00,0x1E, 0x01]
+#                                  lead=0  value=30 (seconds)  flag=1
+#
+# The device then ran exactly 30 s and auto-closed in hardware (cur_cap 0->17 L,
+# switch reported false ~30 s later). So a single watering by duration is:
+#   lead byte = 0  (NOT 1 — the old code's "duration mode = 1" was the bug;
+#                   the firmware ignores lead=1, so the valve "didn't react",
+#                   or cracked open via the flag with no armed timer -> no stop)
+#   value     = duration in seconds
+#   flag      = 1 (start) / 0 (idle/stop)
+LEAD_SINGLE_RUN = 0
+# Volume single-run has NOT been captured from SmartLife yet; this leading byte
+# is an unverified guess kept only for the flow-meter fdm5kw. Valves without
+# no flow meter and cannot hardware-stop by volume, so prefer duration.
+LEAD_VOLUME = 3
+FLAG_START = 1
+FLAG_IDLE = 0
+
+
+def build_one_control_payload(lead: int, value: int, flag: int) -> str:
+    """Build base64-encoded 6-byte one_control DP payload [lead, value(4B BE), flag]."""
+    if not 0 <= value <= 0xFFFFFFFF:
+        raise ValueError(f"value out of range: {value}")
+    payload = bytes(
+        [
+            lead & 0xFF,
+            (value >> 24) & 0xFF,
+            (value >> 16) & 0xFF,
+            (value >> 8) & 0xFF,
+            value & 0xFF,
+            flag & 0xFF,
+        ]
+    )
+    return base64.b64encode(payload).decode("ascii")
+
+
+def _find_multi_manager(hass, device_id: str) -> MultiManager | None:
+    for mm in get_all_multi_managers(hass):
+        if mm.device_map.get(device_id):
+            return mm
+    return None
+
+
+async def _send_commands(
+    multi_manager: MultiManager, device_id: str, commands: list[dict]
+) -> bool:
+    try:
+        ok = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+            multi_manager.send_commands, device_id, commands
+        )
+    except Exception:
+        _LOGGER.exception("DP write failed for %s: %s", device_id, commands)
+        return False
+    if not ok:
+        _LOGGER.warning("DP write rejected for %s: %s", device_id, commands)
+        return False
+    return True
+
+
+async def _write_one_control(
+    multi_manager: MultiManager, device_id: str, b64_value: str
+) -> bool:
+    return await _send_commands(
+        multi_manager, device_id, [{"code": ONE_CONTROL_CODE, "value": b64_value}]
+    )
+
+
+async def start_watering(hass, data: dict) -> bool:
+    """Start a single watering cycle by duration (sec) or volume (L).
+
+    Duration mode sends the exact ``one_control`` payload that SmartLife's own
+    single-watering button sends (lead byte 0, value = seconds, flag = 1) — see
+    the constant block above for the captured packet. The device runs the cycle
+    and auto-closes in hardware after ``value`` seconds, independent of HA/cloud.
+    This replaces the previous lead-byte-1 ("duration mode") payload, which the
+    firmware did not recognise — the cause of the reported "mostly doesn't react / if
+    it opens it never stops" report.
+
+    Volume mode is still best-effort (lead byte unverified, flow-meter only).
+    """
+    device_id: str = data["device_id"]
+    mode: str = data.get("mode", "duration")
+    value: int = int(data["value"])
+    if mode in ("idle", "stop"):
+        raise ValueError("Use stop_watering for mode=idle/stop")
+    if mode not in ("duration", "volume"):
+        raise ValueError(f"mode must be 'duration' or 'volume', got {mode!r}")
+
+    multi_manager = _find_multi_manager(hass, device_id)
+    if multi_manager is None:
+        _LOGGER.error("No multi_manager found for device %s", device_id)
+        return False
+
+    # T3: cyc_control_0 duration run (no one_control DP). Volume-mode cyclic run
+    # not captured — duration only for now.
+    if _is_t3(multi_manager, device_id):
+        if mode == "volume":
+            _LOGGER.warning(
+                "start_watering: T3 %s volume mode unverified, running as duration",
+                device_id,
+            )
+        b64 = build_cyc_control_payload(value, FLAG_START)
+        return await _send_commands(
+            multi_manager, device_id, [{"code": CYC_CONTROL_CODE, "value": b64}]
+        )
+
+    lead = LEAD_SINGLE_RUN if mode == "duration" else LEAD_VOLUME
+    b64 = build_one_control_payload(lead, value, FLAG_START)
+    return await _write_one_control(multi_manager, device_id, b64)
+
+
+async def stop_watering(hass, data: dict) -> bool:
+    """Stop an active watering cycle.
+
+    Writes the SmartLife idle ``one_control`` frame (lead 0, value 0, flag 0) and
+    also drops the ``switch`` DP as a belt-and-braces close. Either being a no-op
+    on a given firmware is harmless.
+    """
+    device_id: str = data["device_id"]
+
+    multi_manager = _find_multi_manager(hass, device_id)
+    if multi_manager is None:
+        _LOGGER.error("No multi_manager found for device %s", device_id)
+        return False
+
+    # T3: cyc_control_0 with flag byte[9]=0 stops the run.
+    if _is_t3(multi_manager, device_id):
+        return await _send_commands(
+            multi_manager,
+            device_id,
+            [{"code": CYC_CONTROL_CODE, "value": build_cyc_control_payload(0, FLAG_IDLE)}],
+        )
+
+    ok = await _write_one_control(
+        multi_manager,
+        device_id,
+        build_one_control_payload(LEAD_SINGLE_RUN, 0, FLAG_IDLE),
+    )
+    await _send_commands(multi_manager, device_id, [{"code": SWITCH_CODE, "value": False}])
+    return ok

--- a/custom_components/xtend_tuya/entity_parser/fdm5kw/init.py
+++ b/custom_components/xtend_tuya/entity_parser/fdm5kw/init.py
@@ -1,0 +1,30 @@
+"""Entity parser plugin for fdm5kw Tuya irrigation valve controller."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.const import (
+    Platform,
+)
+
+from ..entity_parser import (
+    XTCustomEntityParser,
+)
+from .sensor import Fdm5kwSensor
+
+
+def get_plugin_instance() -> XTCustomEntityParser | None:
+    return Fdm5kwEntityParser()
+
+
+class Fdm5kwEntityParser(XTCustomEntityParser):
+    def __init__(self) -> None:
+        super().__init__()
+        Fdm5kwSensor.initialize_sensor()
+
+    def get_descriptors_to_merge(self, platform: Platform) -> Any:
+        match platform:
+            case Platform.SENSOR:
+                return Fdm5kwSensor.get_descriptors_to_merge()
+        return None

--- a/custom_components/xtend_tuya/entity_parser/fdm5kw/location_service.py
+++ b/custom_components/xtend_tuya/entity_parser/fdm5kw/location_service.py
@@ -1,0 +1,174 @@
+"""Build + cache a device_id -> (home, room) map for fdm5kw valves.
+
+A valve's home and room are not in any DP, nor in the SmartLife sharing
+device payload, nor in the OpenAPI thing-model (`bind_space_id` there points
+at the home, and the space tree is empty for these accounts). The room
+grouping lives only in the Tuya OpenAPI *Home Management* API:
+
+    /v1.0/users/{uid}/homes              -> home id + name
+    /v1.0/homes/{home}/rooms             -> room id + name
+    /v1.0/homes/{home}/rooms/{rid}/devices -> which devices are in the room
+
+We fetch it per hub from that hub's `tuya_iot` OpenAPI client, cache the
+result process-wide, and refresh on a slow timer. These are read-only GETs
+that do NOT count against the 10-controllable-devices/month quota (only
+commands do), and the data is near-static, so the cost is negligible.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import timedelta
+from typing import Any
+
+from aiohttp import web
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.http import HomeAssistantView
+
+from ...const import DOMAIN, MESSAGE_SOURCE_TUYA_IOT
+
+_LOGGER = logging.getLogger(__name__)
+
+# device_id -> {"home": str, "room": str}
+LOCATION_MAP: dict[str, dict[str, str]] = {}
+
+# multi_manager ids already put on a refresh timer (avoid stacking intervals
+# and avoid every valve re-walking homes/rooms on startup).
+_SCHEDULED: set[int] = set()
+
+# Called (no args) after LOCATION_MAP changes, so entities can re-publish the
+# new home/room attributes without this module importing the sensor module.
+REFRESH_LISTENERS: list[Callable[[], None]] = []
+
+REFRESH_INTERVAL = timedelta(hours=12)
+
+_VIEW_REGISTERED_KEY = f"{DOMAIN}_valve_locations_view"
+
+
+def _iot_api(multi_manager: Any) -> Any | None:
+    """Return the hub's OpenAPI client, or None if it has no tuya_iot account."""
+    account = multi_manager.accounts.get(MESSAGE_SOURCE_TUYA_IOT)
+    if account is None or getattr(account, "iot_account", None) is None:
+        return None
+    device_manager = account.iot_account.device_manager
+    api = getattr(device_manager, "api", None)
+    if api is None or getattr(api, "token_info", None) is None:
+        return None
+    return api
+
+
+def _build_map(api: Any) -> dict[str, dict[str, str]]:
+    """Blocking — walk homes -> rooms -> room devices for one hub."""
+    result: dict[str, dict[str, str]] = {}
+    uid = getattr(api.token_info, "uid", "") or ""
+    if not uid:
+        return result
+    homes = api.get(f"/v1.0/users/{uid}/homes")
+    if not isinstance(homes, dict) or not homes.get("success"):
+        return result
+    for home in homes.get("result") or []:
+        home_id = home.get("home_id") or home.get("homeId")
+        home_name = home.get("name") or ""
+        if home_id is None:
+            continue
+        rooms = api.get(f"/v1.0/homes/{home_id}/rooms")
+        rooms_result = rooms.get("result") or {}
+        # /homes/{id}/rooms returns either {"rooms": [...]} or a bare list,
+        # depending on DC/account; tolerate both.
+        if isinstance(rooms_result, list):
+            room_list = rooms_result
+        else:
+            room_list = rooms_result.get("rooms") or []
+        for room in room_list:
+            room_id = room.get("room_id")
+            room_name = room.get("name") or ""
+            if room_id is None:
+                continue
+            room_devices = api.get(f"/v1.0/homes/{home_id}/rooms/{room_id}/devices")
+            for dev in room_devices.get("result") or []:
+                device_id = dev.get("device_id") or dev.get("id") or dev.get("dev_id")
+                if device_id:
+                    result[device_id] = {"home": home_name, "room": room_name}
+    return result
+
+
+async def async_refresh(hass: HomeAssistant, multi_manager: Any) -> None:
+    """Refresh the home/room map for one hub. Safe to call repeatedly."""
+    api = _iot_api(multi_manager)
+    if api is None:
+        return
+    try:
+        mapping = await hass.async_add_executor_job(_build_map, api)
+    except Exception:
+        _LOGGER.debug("fdm5kw: valve home/room refresh failed", exc_info=True)
+        return
+    if mapping:
+        LOCATION_MAP.update(mapping)
+        _LOGGER.info(
+            "fdm5kw: refreshed valve home/room for %d devices", len(mapping)
+        )
+        for listener in REFRESH_LISTENERS:
+            try:
+                listener()
+            except Exception:
+                _LOGGER.debug("fdm5kw: location refresh listener failed", exc_info=True)
+
+
+async def async_ensure_scheduled(hass: HomeAssistant, multi_manager: Any) -> None:
+    """Fill the map now and put this hub on a slow refresh timer.
+
+    Guarded per hub: the first valve that lands here triggers one homes/rooms
+    walk and arms the timer; later valves on the same hub are no-ops (they
+    just read the already-filled LOCATION_MAP).
+    """
+    key = id(multi_manager)
+    if key in _SCHEDULED:
+        return
+    _SCHEDULED.add(key)
+
+    # One view registration across all hubs/entries (same pattern as the
+    # calendar ICS view — the view reads the process-wide map at request time).
+    if not hass.data.get(_VIEW_REGISTERED_KEY):
+        hass.http.register_view(XTValveLocationsView())
+        hass.data[_VIEW_REGISTERED_KEY] = True
+
+    await async_refresh(hass, multi_manager)
+
+    async def _tick(_now: Any) -> None:
+        await async_refresh(hass, multi_manager)
+
+    async_track_time_interval(hass, _tick, REFRESH_INTERVAL)
+
+
+def get_location(device_id: str) -> dict[str, str] | None:
+    """Return {'home', 'room'} for a device, or None if unknown."""
+    return LOCATION_MAP.get(device_id)
+
+
+class XTValveLocationsView(HomeAssistantView):
+    """Serve LOCATION_MAP so the dashboard can group OFFLINE valves too.
+
+    An unavailable registry sensor loses its valve_home/valve_room state
+    attributes, so any grouping built from live states shows offline valves
+    as "Unassigned" even though the cloud walk knows their room. This view
+    is backed by the cloud data directly and is keyed by BOTH the Tuya
+    device id and the HA device-registry id (the frontend only has the HA
+    id for a valve whose registry sensor is unavailable).
+    """
+
+    url = f"/api/{DOMAIN}/valve_locations"
+    name = f"api:{DOMAIN}:valve_locations"
+    requires_auth = True
+
+    async def get(self, request: web.Request) -> web.Response:
+        hass: HomeAssistant = request.app["hass"]
+        payload: dict[str, dict[str, str]] = dict(LOCATION_MAP)
+        dev_reg = dr.async_get(hass)
+        for tuya_id, loc in LOCATION_MAP.items():
+            device = dev_reg.async_get_device(identifiers={(DOMAIN, tuya_id)})
+            if device is not None:
+                payload[device.id] = loc
+        return self.json({"locations": payload})

--- a/custom_components/xtend_tuya/entity_parser/fdm5kw/sensor.py
+++ b/custom_components/xtend_tuya/entity_parser/fdm5kw/sensor.py
@@ -1,0 +1,956 @@
+"""Irrigation valve (fdm5kw) data parser for raw Tuya DP codes."""
+
+from __future__ import annotations
+
+import logging
+import struct
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, ClassVar
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import PERCENTAGE, UnitOfVolume, UnitOfVolumeFlowRate
+from homeassistant.helpers.event import async_track_time_interval
+from tuya_device_handlers.definition.sensor import (
+    SensorDefinition as TuyaSensorDefinition,
+)
+
+from ...const import XTDPCode
+from ...ha_tuya_integration.tuya_integration_imports import (
+    TuyaCustomerDevice,
+    TuyaDPCodeRawWrapper,
+    TuyaRawTypeInformation,
+)
+from ...multi_manager.multi_manager import (
+    MultiManager,
+    XTDevice,
+)
+from ...sensor import (
+    XTSensorEntity,
+    XTSensorEntityDescription,
+)
+from . import location_service
+
+_LOGGER = logging.getLogger(__name__)
+
+# DP codes not yet in XTDPCode — use string literals until PR is merged
+DP_ONE_CONTROL = "one_control"
+DP_TIME_TASK = "time_task"
+DP_RUN_TASK_STA = "run_task_sta"
+DP_CUR_CAP = "cur_cap"
+DP_START_TIME = "start_time"
+
+# Liters ceiling for one cur_cap reading (25 L/min impeller * 6 h cap). The
+# cur_cap DP occasionally emits a garbage spike (e.g. 177610 L); a spike would
+# otherwise produce an impossible derived flow burst (e.g. 260000 L/min).
+SANE_CUR_CAP_MAX = 9000
+
+# How often to re-publish the flow-rate sensor state while a run is active.
+# Pure local recomputation (no API call) — cost is one recorder row per tick
+# per running valve. 10s was chosen as the practical floor in testing.
+FLOW_RATE_REFRESH = timedelta(seconds=10)
+
+from .const import DAYS_OF_WEEK, DEVICE_CATEGORY
+
+# ---------------------------------------------------------------------------
+# Raw DP Wrappers
+# ---------------------------------------------------------------------------
+
+
+class XTDPCodeRawStatusWrapper(TuyaDPCodeRawWrapper):
+    """Raw DP wrapper that also binds on status presence.
+
+    tuya-device-handlers 0.0.22 changed ``DPCodeWrapper.find_dpcode`` to bind
+    only when the DP is declared in the device *spec* (``device.function`` /
+    ``device.status_range``) with ``type == RAW``. fdm5kw valves obtained over
+    the sharing API report ``time_task`` / ``start_time`` / ``close_time`` /
+    ``one_control`` as *status values* only — the sharing spec lists just DPs
+    1 + 11 — so the strict lookup returns ``None`` and the timer/name/last-run
+    entities silently vanish (regressed in the 0.0.22 merge, v4.4.181: ~85 of
+    100 valves dropped to the bare "Valve" entity with no timer).
+
+    Restore the pre-0.0.22 behaviour: try the spec-based lookup first (so
+    OpenAPI-spec devices keep their real type information), and only if that
+    misses, synthesize a ``RawTypeInformation`` from a DP that is present in
+    ``device.status``. ``RawTypeInformation.read_device_value`` reads straight
+    from ``device.status`` and base64-decodes — it never consults ``type_data``
+    — so a synthesized instance decodes identically.
+    """
+
+    @classmethod
+    def find_dpcode(
+        cls,
+        device: TuyaCustomerDevice,
+        dpcodes: str | tuple[str, ...] | None,
+        *,
+        prefer_function: bool = False,
+    ):
+        if wrapper := super().find_dpcode(
+            device, dpcodes, prefer_function=prefer_function
+        ):
+            return wrapper
+        if dpcodes is None:
+            return None
+        if not isinstance(dpcodes, tuple):
+            dpcodes = (dpcodes,)
+        for dpcode in dpcodes:
+            if device.status.get(dpcode) is not None:
+                return cls(
+                    dpcode=dpcode,
+                    type_information=TuyaRawTypeInformation(
+                        dpcode=dpcode, type_data="{}", report_type=None
+                    ),
+                )
+        return None
+
+
+class DPCodeTimestampWrapper(XTDPCodeRawStatusWrapper):
+    """Decodes start_time / close_time: 6 bytes [year_offset, month, day, hour, minute, second]."""
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        if (decoded := super().read_device_status(device)) and len(decoded) == 6:
+            y, mo, d, h, mi, s = struct.unpack("BBBBBB", decoded)
+            # 0xFF bytes = no data / unset
+            if y == 255 or mo == 0 or mo > 12 or d == 0 or d > 31:
+                return None
+            return f"20{y:02d}-{mo:02d}-{d:02d} {h:02d}:{mi:02d}:{s:02d}"
+        return None
+
+
+class DPCodeOneControlWrapper(XTDPCodeRawStatusWrapper):
+    """Decodes one_control: 6 bytes [mode, param_hi, param_mid_hi, param_mid_lo, param_lo, ?]."""
+
+    def __init__(self, dpcode: str, type_information: TuyaRawTypeInformation) -> None:
+        super().__init__(dpcode, type_information)
+        self.mode: int | None = None
+        self.value: int | None = None
+
+    def update_data(self, device: TuyaCustomerDevice) -> None:
+        if (decoded := super().read_device_status(device)) and len(decoded) >= 6:
+            self.mode = decoded[0]
+            self.value = int.from_bytes(decoded[1:5], byteorder="big")
+
+
+class DPCodeOneControlModeWrapper(DPCodeOneControlWrapper):
+    """Returns the one_control *status* mode label.
+
+    one_control status mirrors the last command payload [lead, value(4B BE), flag].
+    Verified live 2026-06-09 by triggering single-waterings on 964 and reading status:
+        idle (no single-watering):  [0,0,0,0,0,0]      value 0
+        duration run/armed:         [0,0,0,V,V,1]      lead 0, value = seconds  (964=900, 977=10)
+        volume run/armed:           [1,0,0,0,V,1]      lead 1, value = liters   (964 volume 5L → [1,0,0,0,5,1])
+    So lead byte 0 = duration, 1 = volume — the same encoding as time_task's mode
+    byte (0=duration, 1=volume). The pre-4.4.183 note in irrigation-dp-decoding.md
+    (0=idle / 1=duration / 3=volume) was stale and is wrong on every count.
+
+    A zero value means no single-watering is set -> "idle" (covers both a truly idle
+    valve and a just-finished run, where the device clears the value but keeps the
+    last lead byte). A non-zero value -> the lead byte gives the mode.
+    """
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        self.update_data(device)
+        if self.mode is None:
+            return None
+        if not self.value:
+            return "idle"
+        if self.mode == 0:
+            return "duration"
+        if self.mode == 1:
+            return "volume"
+        return f"unknown ({self.mode})"
+
+
+class DPCodeOneControlValueWrapper(DPCodeOneControlWrapper):
+    """Returns the one_control parameter value (duration in sec or volume in L)."""
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> int | None:
+        self.update_data(device)
+        return self.value
+
+
+class DPCodeTimeTaskWrapper(XTDPCodeRawStatusWrapper):
+    """Decodes time_task: 11 bytes.
+
+    Layout (corrected 2026-06-05 against live SmartLife app toggles):
+    [slot_index, enabled, mode, value(4 bytes uint32 BE), hour, minute,
+     days_bitmask, const].
+    - byte[1] = enable flag: 1=active, 0=disabled. SmartLife flips exactly
+      this byte when you toggle a timer off/on; the rest of the payload is
+      retained. (The old spec mislabelled this "count/always 1" — every
+      sample then was active so byte[1] and byte[10] couldn't be told apart.)
+    - byte[10] = constant 1 (NOT "enabled", as previously assumed).
+    A true delete is byte[1]==0 with an all-zero payload; a merely disabled
+    timer is byte[1]==0 with its real payload intact.
+
+    The DP acts as a sliding window — only shows the last-written timer slot.
+    The device stores all timers internally. Each edit pushes that slot's data.
+
+    Mode: 0=duration (value in seconds), 1=volume (value in liters)
+    Days bitmask: bit0=Mon, bit1=Tue, ..., bit6=Sun
+    """
+
+    def __init__(self, dpcode: str, type_information: TuyaRawTypeInformation) -> None:
+        super().__init__(dpcode, type_information)
+        self.slot_index: int = 0
+        self.timer: dict | None = None
+
+    def update_data(self, device: TuyaCustomerDevice) -> None:
+        if decoded := super().read_device_status(device):
+            if len(decoded) < 11:
+                return
+            self.slot_index = decoded[0]
+            entry = decoded[2:11]
+            # byte[1] is the enable flag (1=active, 0=disabled), NOT a count.
+            # A true delete is byte[1]==0 AND an all-zero payload; a disabled
+            # timer keeps its full payload with byte[1]==0 — keep it (greyed),
+            # don't drop it (that was the "timer vanishes in HA" bug).
+            enabled = decoded[1]
+            if enabled == 0 and not any(entry):
+                self.timer = None
+                return
+            mode = entry[0]
+            value = int.from_bytes(entry[1:5], byteorder="big")
+            hour = entry[5]
+            minute = entry[6]
+            days_mask = entry[7]
+            # entry[8] == decoded[10] is a constant 1, not the enable flag.
+            days = [
+                DAYS_OF_WEEK[i] for i in range(7) if days_mask & (1 << i)
+            ]
+            self.timer = {
+                "slot": self.slot_index,
+                "hour": hour,
+                "minute": minute,
+                "mode": "duration" if mode == 0 else "volume",
+                "value": value,
+                "value_unit": "s" if mode == 0 else "L",
+                "days": days,
+                "days_mask": days_mask,
+                "enabled": bool(enabled),
+            }
+
+
+class DPCodeTimeTaskSlotWrapper(DPCodeTimeTaskWrapper):
+    """Returns the slot index of the last-modified timer."""
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> int | None:
+        self.update_data(device)
+        return self.slot_index if self.timer else None
+
+
+class DPCodeTimeTaskSummaryWrapper(DPCodeTimeTaskWrapper):
+    """Returns a human-readable summary of the last-modified timer."""
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        self.update_data(device)
+        if not self.timer:
+            return "No timer data"
+        t = self.timer
+        status = "ON" if t["enabled"] else "OFF"
+        days_str = ",".join(t["days"]) if t["days"] else "none"
+        if t["mode"] == "duration":
+            duration_min = t["value"] // 60
+            return (
+                f"Slot {t['slot']}: {t['hour']:02d}:{t['minute']:02d} "
+                f"{duration_min}min {days_str} [{status}]"
+            )
+        return (
+            f"Slot {t['slot']}: {t['hour']:02d}:{t['minute']:02d} "
+            f"{t['value']}L {days_str} [{status}]"
+        )
+
+
+class DPCodeTimeTaskRegistryWrapper(DPCodeTimeTaskWrapper):
+    """Accumulates all 7 timer slots across DP updates.
+
+    The device's time_task DP is a sliding window that only shows the
+    last-written slot. This wrapper maintains a dict of all 7 slots,
+    updating each slot as its data comes through the DP. The registry
+    persists across HA restarts via the companion entity's state
+    restoration. The device DP is the single source of truth — no cloud
+    timer registry is consulted.
+    """
+
+    NUM_SLOTS = 7
+
+    def __init__(self, dpcode: str, type_information: TuyaRawTypeInformation) -> None:
+        super().__init__(dpcode, type_information)
+        self.slots: dict[int, dict | None] = {i: None for i in range(self.NUM_SLOTS)}
+        # The DP is a sliding window that shows the last write/delete. Apply
+        # each unique payload to slots once; without this guard, every state
+        # read would re-apply the last delete and wipe a previously restored
+        # slot.
+        self._last_applied_payload: bytes | None = None
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        """Parse DP, apply once per unique payload, return active count."""
+        raw = super().read_device_status(device)
+        payload = bytes(raw) if isinstance(raw, (bytes, bytearray)) else None
+        if payload is not None and payload != self._last_applied_payload:
+            self.update_data(device)
+            if self.timer is not None:
+                idx = self.timer["slot"]
+                if 0 <= idx < self.NUM_SLOTS:
+                    self.slots[idx] = dict(self.timer)
+                    # Tuya's cloud registry can map two timers onto the same
+                    # device slot (seen live on 969: 04:05 and 22:05 both as
+                    # slot 1). When that slot's push carries a time+days that
+                    # another slot already holds, the other entry is a stale
+                    # duplicate of this same timer — drop it so the registry
+                    # doesn't show one timer twice / a ghost that never fires.
+                    for other, s in self.slots.items():
+                        if (
+                            other != idx
+                            and s
+                            and s.get("hour") == self.timer["hour"]
+                            and s.get("minute") == self.timer["minute"]
+                            and s.get("days_mask") == self.timer["days_mask"]
+                        ):
+                            _LOGGER.warning(
+                                "time_task slot %d duplicates slot %d (%02d:%02d) — dropping stale entry",
+                                other,
+                                idx,
+                                self.timer["hour"],
+                                self.timer["minute"],
+                            )
+                            self.slots[other] = None
+            elif self.slot_index is not None and 0 <= self.slot_index < self.NUM_SLOTS:
+                # count=0 means slot was deleted
+                self.slots[self.slot_index] = None
+            self._last_applied_payload = payload
+        active = sum(1 for s in self.slots.values() if s and s.get("enabled"))
+        return str(active)
+
+    def get_slots_dict(self) -> dict[str, dict | None]:
+        """Return slots keyed by string index (for JSON-safe HA attributes)."""
+        return {str(k): v for k, v in self.slots.items()}
+
+    def restore_slots(self, data: dict) -> None:
+        """Hydrate slots from HA state restoration."""
+        for i in range(self.NUM_SLOTS):
+            slot_data = data.get(str(i)) or data.get(i)
+            if isinstance(slot_data, dict):
+                self.slots[i] = slot_data
+            else:
+                self.slots[i] = None
+
+
+# ---------------------------------------------------------------------------
+# Custom Entity for Timer Registry
+# ---------------------------------------------------------------------------
+
+
+class Fdm5kwTimerRegistryEntity(XTSensorEntity):
+    """Sensor that exposes all 7 timer slots as attributes.
+
+    State value = count of active (enabled) timers.
+    Attributes contain the full slot registry for the irrigation-timer-card.
+    Slots accumulate from the device's time_task DP push events; the
+    registry survives HA restarts via state restoration.
+    """
+
+    # device_id → live entity instance
+    INSTANCES: ClassVar[dict[str, Fdm5kwTimerRegistryEntity]] = {}
+
+    @property
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
+        wrapper = self._dpcode_wrapper
+        if not isinstance(wrapper, DPCodeTimeTaskRegistryWrapper):
+            return None
+        slots = wrapper.get_slots_dict()
+        active = sum(1 for s in slots.values() if s and s.get("enabled"))
+        location = location_service.get_location(self.device.id) or {}
+        return {
+            "slots": slots,
+            "active_count": active,
+            "valve_name": self.device.name,
+            "valve_home": location.get("home"),
+            "valve_room": location.get("room"),
+            "device_id": self.device.id,
+            "product_name": getattr(self.device, "product_name", None),
+        }
+
+    async def async_added_to_hass(self) -> None:
+        """Restore slot registry from previous HA state."""
+        await super().async_added_to_hass()
+        Fdm5kwTimerRegistryEntity.INSTANCES[self.device.id] = self
+
+        # Populate the valve home/room map (and put the owning hub on a slow
+        # refresh) the first time any timer sensor is added. Fire-and-forget:
+        # a location fetch must never block or break entity setup.
+        multi_manager = self.device.get_multi_manager(self.hass)
+        if multi_manager is not None:
+            self.hass.async_create_task(
+                location_service.async_ensure_scheduled(self.hass, multi_manager)
+            )
+
+        wrapper = self._dpcode_wrapper
+        if not isinstance(wrapper, DPCodeTimeTaskRegistryWrapper):
+            return
+
+        # Prime the idempotency guard with the device's current DP payload
+        # before restoring slots; otherwise the next state read would re-apply
+        # the last DP push (often a delete) and trample the restored data.
+        try:
+            wrapper.read_device_status(self.device)
+        except Exception:
+            _LOGGER.debug(
+                "fdm5kw: priming read_device_status for %s failed",
+                self.entity_id,
+                exc_info=True,
+            )
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            slots_data = last_state.attributes.get("slots")
+            if isinstance(slots_data, dict):
+                wrapper.restore_slots(slots_data)
+                _LOGGER.debug(
+                    "Restored timer registry for %s: %s",
+                    self.entity_id,
+                    slots_data,
+                )
+
+        # Force a state write so attributes (valve_name, slots, etc.) reach
+        # the frontend immediately. Without this, devices that haven't seen
+        # a fresh DP push since boot keep the prior boot's attributes — the
+        # dashboard strategy then falls back to device_id for the tile name.
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        Fdm5kwTimerRegistryEntity.INSTANCES.pop(self.device.id, None)
+        await super().async_will_remove_from_hass()
+
+
+def _republish_valve_location() -> None:
+    """Re-publish timer-registry state so newly-fetched home/room attributes
+    reach the frontend immediately (the map fills async, after the entities'
+    first state write). Runs in the event loop via location_service."""
+    for entity in list(Fdm5kwTimerRegistryEntity.INSTANCES.values()):
+        if entity.hass is not None:
+            entity.async_write_ha_state()
+
+
+if _republish_valve_location not in location_service.REFRESH_LISTENERS:
+    location_service.REFRESH_LISTENERS.append(_republish_valve_location)
+
+
+# ---------------------------------------------------------------------------
+# Custom Entity for Derived Flow Rate (l/min)
+# ---------------------------------------------------------------------------
+
+
+class Fdm5kwFlowRateEntity(XTSensorEntity):
+    """Derived instantaneous flow-rate sensor (liters/minute).
+
+    Uses a differential method: between two 10 s samples, flow rate is
+    `(cur_cap_now - cur_cap_prev) * 60 / delta_seconds`. The FDM5KW has
+    a real Hall-effect impeller inside the valve body (2–25 L/min range
+    per the QOTO QT-08W spec), so `cur_cap` reflects actual liters and
+    the resulting graph captures real flow variations — pressure dips,
+    partial restrictions, etc.
+
+    The 10 s tick is purely local: it reads `device.status["cur_cap"]`,
+    which is kept fresh by the upstream MQTT push. No Tuya API calls
+    are issued.
+
+    Idle state (run_task_sta != 1) reports 0.0. Below ~2 L/min the
+    impeller doesn't tick and `cur_cap` stalls, so the derived rate
+    will read 0 even with water flowing — a hardware limit, not a bug.
+    """
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 2
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._refresh_unsub: Callable[[], None] | None = None
+        self._was_running: bool = False
+        self._last_cur_cap: int | None = None
+        # Monotonic, not wall clock: this timestamp is only ever used to
+        # measure the elapsed seconds between two cur_cap samples. A DST
+        # change or an NTP step would otherwise land straight in the
+        # divisor and produce a nonsense flow-rate spike.
+        self._last_ts: float | None = None
+        self._current_flow: float = 0.0
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        # Hard-coded as a property to defeat the base XTSensorEntity's
+        # unit inheritance from the `cur_cap` Tuya DP data-model, which
+        # carries a Chinese-localized "升 (L)" unit string. This sensor
+        # is a derived rate; force "L/min" regardless of what the upstream
+        # DP definition says.
+        return str(UnitOfVolumeFlowRate.LITERS_PER_MINUTE)
+
+    @property
+    def device_class(self) -> str | None:
+        # Same reason: prevent the base class from injecting
+        # SensorDeviceClass.WATER which forces a volume unit.
+        return None
+
+    @property
+    def native_value(self) -> float:
+        return self._current_flow
+
+    def _recompute(self) -> bool:
+        """Update self._current_flow. Returns True if a state write
+        should fire (state changed, or run is active and the recorder
+        wants a fresh row)."""
+        running = self.device.status.get(DP_RUN_TASK_STA) == 1
+        cur_cap_raw = self.device.status.get(DP_CUR_CAP) or 0
+        try:
+            cur_cap = int(cur_cap_raw)
+        except (TypeError, ValueError):
+            cur_cap = 0
+        now = time.monotonic()
+
+        if not running:
+            changed = self._was_running or self._current_flow != 0.0
+            self._current_flow = 0.0
+            self._last_cur_cap = None
+            self._last_ts = None
+            self._was_running = False
+            return changed
+
+        if cur_cap > SANE_CUR_CAP_MAX:
+            # Glitch spike in the cur_cap DP — ignore this sample so the
+            # derived rate doesn't show an impossible burst. Keep the last
+            # baseline; the next real reading resumes a sane delta.
+            return False
+
+        if not self._was_running or self._last_ts is None or self._last_cur_cap is None:
+            # Run just started: capture baseline, emit 0 once.
+            self._last_cur_cap = cur_cap
+            self._last_ts = now
+            changed = self._current_flow != 0.0 or not self._was_running
+            self._current_flow = 0.0
+            self._was_running = True
+            return changed
+
+        delta_t = now - self._last_ts
+        if delta_t <= 0:
+            return False
+        delta_cap = max(0, cur_cap - self._last_cur_cap)
+        self._current_flow = round(delta_cap * 60.0 / delta_t, 2)
+        self._last_cur_cap = cur_cap
+        self._last_ts = now
+        self._was_running = True
+        # Always emit while running so the graph has dense rows.
+        return True
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._refresh_unsub = async_track_time_interval(
+            self.hass, self._on_tick, FLOW_RATE_REFRESH
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._refresh_unsub is not None:
+            self._refresh_unsub()
+            self._refresh_unsub = None
+        await super().async_will_remove_from_hass()
+
+    async def _on_tick(self, _now: datetime) -> None:
+        if self._recompute():
+            self.async_write_ha_state()
+
+
+# ---------------------------------------------------------------------------
+# QT-08W-T3 valve — raw DP wrappers (product rjnqkjk1pct15ku2)
+# ---------------------------------------------------------------------------
+# The T3 is a DIFFERENT product from the QT-08W (o6dagifntoafakst): indexed DP
+# model (switch_1, time_task_0, flow_sta_0, sat_0, counter_custom), no
+# vbat_state / cur_cap / one_control. Battery is byte-packed inside sat_0.
+# Decoders validated against live captures 2026-07-15 — see
+# ~/Documents/work/irrigation-t3-dp-decode.md. All descriptors below are
+# DP-presence-gated, so they only spawn on T3 devices and never touch the old
+# QT-08W (which lacks these codes) — same coexistence model as every other
+# fdm5kw descriptor.
+
+DP_T3_SAT = "sat_0"
+DP_T3_FLOW_STA = "flow_sta_0"
+DP_T3_COUNTER = "counter_custom"
+
+
+class DPCodeSat0BatteryWrapper(XTDPCodeRawStatusWrapper):
+    """T3 battery %: sat_0 byte[3] low 7 bits (high bit = charge/sun flag).
+
+    sat_0 = 00 01 00 [BB] 00 01 00 [Y M D H M] 00 (13 B). 706 read 0x64=100,
+    matching SmartLife's 100%.
+    """
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        decoded = super().read_device_status(device)
+        if decoded and len(decoded) >= 4:
+            # ponytail: a lone byte3=0x00 glitch was seen once (07-13); returns
+            # 0% for that frame. Debounce here if it proves noisy in the field.
+            return str(decoded[3] & 0x7F)
+        return None
+
+
+class DPCodeSat0NextRunWrapper(XTDPCodeRawStatusWrapper):
+    """T3 next-irrigation time from sat_0 bytes[7..11] = [Y-2000, M, D, H, M].
+    0xFF year / month 0 (idle frame `..ff ff ff ff ff`) = no schedule -> None."""
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        decoded = super().read_device_status(device)
+        if decoded and len(decoded) >= 12:
+            y, mo, d, h, mi = decoded[7], decoded[8], decoded[9], decoded[10], decoded[11]
+            if y == 0xFF or mo == 0 or mo > 12 or d == 0 or d > 31:
+                return None
+            return f"20{y:02d}-{mo:02d}-{d:02d} {h:02d}:{mi:02d}:00"
+        return None
+
+
+class DPCodeFlowStaVolumeWrapper(XTDPCodeRawStatusWrapper):
+    """T3 watering volume (L): flow_sta_0 bytes[1:5] BE. Live-cumulative during a
+    run, holds the last run's final total when idle. Captured mid-run 07-14:
+    climbed 80..113 L; final frame bytes[1:5]=00 00 00 71 = 113 L (=app 113 L).
+    """
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        decoded = super().read_device_status(device)
+        if decoded and len(decoded) >= 5:
+            vol = int.from_bytes(decoded[1:5], "big")
+            if vol > SANE_CUR_CAP_MAX:
+                return None  # glitch guard, same ceiling as cur_cap
+            return str(vol)
+        return None
+
+
+class DPCodeCounterCustomWrapper(XTDPCodeRawStatusWrapper):
+    """T3 counter_custom — a plain CSV STRING (not base64), last completed run:
+    'mode,flag,duration_s,volume_L,timestamp'. e.g. '0,1,600,113,20260714161000'.
+    duration 65534 (0xFFFE) = aborted/interrupted sentinel."""
+
+    def _parse(self, device: TuyaCustomerDevice) -> dict | None:
+        raw = device.status.get(self.dpcode)
+        if not isinstance(raw, str) or "," not in raw:
+            return None
+        parts = raw.split(",")
+        if len(parts) < 5:
+            return None
+        try:
+            return {"duration": int(parts[2]), "volume": int(parts[3]), "ts": parts[4]}
+        except ValueError:
+            return None
+
+
+class DPCodeCounterCustomVolumeWrapper(DPCodeCounterCustomWrapper):
+    """Last completed-run volume (L). Skips the 0xFFFE aborted sentinel."""
+
+    def read_device_status(self, device: TuyaCustomerDevice) -> str | None:
+        p = self._parse(device)
+        if not p or p["duration"] == 65534:
+            return None
+        return str(p["volume"])
+
+
+DP_T3_TIME_TASK = "time_task_0"
+
+
+class DPCodeT3TimeTaskWrapper(DPCodeTimeTaskWrapper):
+    """T3 time_task_0 — 12 bytes, same sliding-window + per-timer-index model as
+    the old valve, but a different layout (verified live 2026-07-15):
+      [00, index, b2, mode, value(4B BE), hour, minute, days_mask, enabled]
+    - byte[1] = per-timer index (the T3 equivalent of the old byte[0] slot) —
+      PROVEN with two duration timers (A idx0, B idx1). NOT the enable flag.
+    - byte[3] = mode (0=duration/seconds, 1=volume/liters).
+    - byte[11] = enabled (1=active, 0=disabled).
+    - byte[2] = a create/order marker (1 only on the create push), ignored.
+    Ghost caveat (proven live): a SmartLife delete does NOT clear the DP or set
+    enabled=0 — the device keeps re-reporting the stale timer. So, exactly like
+    the old valve, deletions are invisible on the DP and need the reactive
+    resync path; only an all-zero payload counts as an empty slot here.
+    """
+
+    def update_data(self, device: TuyaCustomerDevice) -> None:
+        if decoded := super().read_device_status(device):
+            if len(decoded) < 12:
+                return
+            self.slot_index = decoded[1]
+            mode = decoded[3]
+            value = int.from_bytes(decoded[4:8], byteorder="big")
+            hour = decoded[8]
+            minute = decoded[9]
+            days_mask = decoded[10]
+            enabled = decoded[11]
+            # Empty/cleared slot = an all-zero payload (what a slot clear writes).
+            if not value and not hour and not minute and not days_mask and not enabled:
+                self.timer = None
+                return
+            days = [DAYS_OF_WEEK[i] for i in range(7) if days_mask & (1 << i)]
+            self.timer = {
+                "slot": self.slot_index,
+                "hour": hour,
+                "minute": minute,
+                "mode": "duration" if mode == 0 else "volume",
+                "value": value,
+                "value_unit": "s" if mode == 0 else "L",
+                "days": days,
+                "days_mask": days_mask,
+                "enabled": bool(enabled),
+            }
+
+
+# The Slot/Summary/Registry variants reuse the old read/accumulate logic and
+# only swap in the T3 decoder via MRO (T3 update_data resolves before the base).
+class DPCodeT3TimeTaskSlotWrapper(DPCodeTimeTaskSlotWrapper, DPCodeT3TimeTaskWrapper):
+    pass
+
+
+class DPCodeT3TimeTaskSummaryWrapper(DPCodeTimeTaskSummaryWrapper, DPCodeT3TimeTaskWrapper):
+    pass
+
+
+class DPCodeT3TimeTaskRegistryWrapper(DPCodeTimeTaskRegistryWrapper, DPCodeT3TimeTaskWrapper):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Entity Descriptors
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Fdm5kwSensorEntityDescription(XTSensorEntityDescription):
+    """Describes fdm5kw irrigation valve sensor entity."""
+
+
+
+@dataclass(frozen=True)
+class Fdm5kwTimerRegistryDescription(Fdm5kwSensorEntityDescription):
+    """Descriptor that returns a Fdm5kwTimerRegistryEntity instead of base XTSensorEntity."""
+
+    def get_entity_instance(
+        self,
+        device: XTDevice,
+        device_manager: MultiManager,
+        description: XTSensorEntityDescription,
+        definition: TuyaSensorDefinition,
+        supported_descriptors: dict[str, tuple[XTSensorEntityDescription, ...]],
+    ) -> Fdm5kwTimerRegistryEntity:
+        return Fdm5kwTimerRegistryEntity(
+            device=device,
+            device_manager=device_manager,
+            description=XTSensorEntityDescription(**description.__dict__),
+            definition=definition,
+            supported_descriptors=supported_descriptors,
+        )
+
+
+@dataclass(frozen=True)
+class Fdm5kwFlowRateDescription(Fdm5kwSensorEntityDescription):
+    """Descriptor that returns a Fdm5kwFlowRateEntity (derived l/min)."""
+
+    def get_entity_instance(
+        self,
+        device: XTDevice,
+        device_manager: MultiManager,
+        description: XTSensorEntityDescription,
+        definition: TuyaSensorDefinition,
+        supported_descriptors: dict[str, tuple[XTSensorEntityDescription, ...]],
+    ) -> Fdm5kwFlowRateEntity:
+        return Fdm5kwFlowRateEntity(
+            device=device,
+            device_manager=device_manager,
+            description=XTSensorEntityDescription(**description.__dict__),
+            definition=definition,
+            supported_descriptors=supported_descriptors,
+        )
+
+
+class Fdm5kwSensor:
+    FDM5KW_SENSORS: ClassVar[dict[str, tuple[XTSensorEntityDescription, ...]]] = {}
+
+    @staticmethod
+    def initialize_sensor() -> None:
+        sensors: list[Fdm5kwSensorEntityDescription] = [
+            # --- Timestamps ---
+            # translation_key is what the strategy + calendar use to map a
+            # sibling entity to its role (start/end/mode/registry). Existing
+            # entities created before 4.4.150 have null translation_key in
+            # the entity registry; the strategy + calendar fall back to
+            # entity-id suffix matching for those.
+            # NOTE: every descriptor below sets ignore_other_dp_code_handler=True.
+            # Three descriptors share dpcode=time_task and two share one_control,
+            # so the first to register marks the DP "handled" and the rest would
+            # be suppressed by _supports_description (entity.py). Worse, once any
+            # of these entities orphans (e.g. a hub re-add / device-id churn),
+            # register_current_entities_as_handled_dpcode marks the DP handled on
+            # every boot, so the parser permanently suppresses re-creating them
+            # (the "914 timer never shows" regression). The flag makes each
+            # entity register regardless — same fix as the cur_cap flow_rate race.
+            Fdm5kwSensorEntityDescription(
+                key=f"{XTDPCode.START_TIME}_timestamp",
+                dpcode=XTDPCode.START_TIME,
+                translation_key="start_time",
+                name="Last watering start",
+                icon="mdi:clock-start",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeTimestampWrapper,),
+            ),
+            Fdm5kwSensorEntityDescription(
+                key=f"{XTDPCode.CLOSE_TIME}_timestamp",
+                dpcode=XTDPCode.CLOSE_TIME,
+                translation_key="close_time",
+                name="Last watering end",
+                icon="mdi:clock-end",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeTimestampWrapper,),
+            ),
+            # --- One-shot control status ---
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_ONE_CONTROL}_mode",
+                dpcode=DP_ONE_CONTROL,
+                translation_key="watering_mode",
+                name="Watering mode",
+                icon="mdi:water-pump",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeOneControlModeWrapper,),
+            ),
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_ONE_CONTROL}_value",
+                dpcode=DP_ONE_CONTROL,
+                translation_key="watering_value",
+                name="Watering value",
+                icon="mdi:water",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeOneControlValueWrapper,),
+            ),
+            # --- Timer schedule ---
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_TIME_TASK}_slot",
+                dpcode=DP_TIME_TASK,
+                translation_key="timer_slot",
+                name="Timer slot",
+                icon="mdi:timer-outline",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeTimeTaskSlotWrapper,),
+            ),
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_TIME_TASK}_summary",
+                dpcode=DP_TIME_TASK,
+                translation_key="timer_schedule",
+                name="Timer schedule",
+                icon="mdi:calendar-clock",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeTimeTaskSummaryWrapper,),
+            ),
+            # --- Timer registry (accumulates all 7 slots) ---
+            Fdm5kwTimerRegistryDescription(
+                key=f"{DP_TIME_TASK}_registry",
+                dpcode=DP_TIME_TASK,
+                translation_key="irrigation_timer_registry",
+                name="Irrigation timer registry",
+                icon="mdi:timer-cog",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeTimeTaskRegistryWrapper,),
+            ),
+            # --- Derived flow rate (l/min) for watering-history graph ---
+            # ignore_other_dp_code_handler keeps the upstream cur_cap
+            # `watering_volume` entity registering even though both
+            # descriptors share dpcode=cur_cap. Without it, the first
+            # descriptor to register claims the DP and the other entity
+            # never spawns -> "Volume Unavailable" in the Last Watering
+            # card after the v4.4.136 upgrade.
+            Fdm5kwFlowRateDescription(
+                key=f"{DP_CUR_CAP}_flow_rate",
+                dpcode=DP_CUR_CAP,
+                translation_key="watering_flow_rate",
+                name="Watering flow rate",
+                icon="mdi:water-percent",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+            ),
+            # --- QT-08W-T3 valve (product rjnqkjk1pct15ku2) ---
+            # DP-presence-gated to T3; these codes are absent on the old QT-08W.
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_T3_SAT}_battery",
+                dpcode=DP_T3_SAT,
+                translation_key="battery",
+                name="Battery level",
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=PERCENTAGE,
+                state_class=SensorStateClass.MEASUREMENT,
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeSat0BatteryWrapper,),
+            ),
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_T3_FLOW_STA}_volume",
+                dpcode=DP_T3_FLOW_STA,
+                translation_key="watering_volume",
+                name="Watering volume",
+                device_class=SensorDeviceClass.WATER,
+                native_unit_of_measurement=UnitOfVolume.LITERS,
+                icon="mdi:water",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeFlowStaVolumeWrapper,),
+            ),
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_T3_SAT}_next_run",
+                dpcode=DP_T3_SAT,
+                translation_key="next_watering",
+                name="Next watering",
+                icon="mdi:clock-outline",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeSat0NextRunWrapper,),
+            ),
+            # T3 timers — same registry/slot/summary as the old valve, on
+            # time_task_0 with the 12-byte decoder. Matching translation_keys so
+            # the dashboard strategy + timer card treat T3 like the old valves.
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_T3_TIME_TASK}_slot",
+                dpcode=DP_T3_TIME_TASK,
+                translation_key="timer_slot",
+                name="Timer slot",
+                icon="mdi:timer-outline",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeT3TimeTaskSlotWrapper,),
+            ),
+            Fdm5kwSensorEntityDescription(
+                key=f"{DP_T3_TIME_TASK}_summary",
+                dpcode=DP_T3_TIME_TASK,
+                translation_key="timer_schedule",
+                name="Timer schedule",
+                icon="mdi:calendar-clock",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeT3TimeTaskSummaryWrapper,),
+            ),
+            Fdm5kwTimerRegistryDescription(
+                key=f"{DP_T3_TIME_TASK}_registry",
+                dpcode=DP_T3_TIME_TASK,
+                translation_key="irrigation_timer_registry",
+                name="Irrigation timer registry",
+                icon="mdi:timer-cog",
+                entity_registry_enabled_default=True,
+                ignore_other_dp_code_handler=True,
+                wrapper_class=(DPCodeT3TimeTaskRegistryWrapper,),
+            ),
+        ]
+
+        Fdm5kwSensor.FDM5KW_SENSORS = {
+            DEVICE_CATEGORY: tuple(sensors),
+        }
+
+    @staticmethod
+    def get_descriptors_to_merge() -> (
+        dict[str, tuple[XTSensorEntityDescription, ...]] | None
+    ):
+        return Fdm5kwSensor.FDM5KW_SENSORS

--- a/custom_components/xtend_tuya/entity_parser/fdm5kw/timer_service.py
+++ b/custom_components/xtend_tuya/entity_parser/fdm5kw/timer_service.py
@@ -1,0 +1,760 @@
+"""Dual-write timer services for fdm5kw irrigation valve.
+
+The device-side `time_task` DP executes locally and is offline-safe, but
+empirical testing on 2026-05-12 against live hardware showed that
+Tuya's cloud rewrites the device DP from the cloud timer registry ~10s
+after a direct DP write. To make HA → SmartLife mutations durable we
+write both: the DP for immediate local execution, then the cloud timer
+registry (via OpenAPI) so the cloud doesn't roll back our change.
+
+Cost: 1–2 OpenAPI calls per user-initiated timer mutation (set/delete).
+Negligible compared to the historical periodic-poll regressions —
+mutations are interactive, not on a timer.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+from typing import Any
+
+from ...multi_manager.multi_manager import MultiManager
+from ...multi_manager.shared.threading import XTEventLoopProtector
+from ...util import get_all_multi_managers
+from .const import (
+    DAYS_OF_WEEK,
+    TUYA_ERR_DEVICE_POOL_QUOTA,
+    TUYA_ERR_DEVICE_POOL_QUOTA_MSG,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+TIME_TASK_CODE = "time_task"
+# QT-08W-T3 valves carry the indexed `time_task_0` DP instead of `time_task`,
+# with a 12-byte payload (per-timer index at byte[1], not byte[0]). Same
+# sliding-window model — only the DP code + byte layout differ, so the write
+# path branches on device.status presence. See t3_valve_dp_decode memory.
+TIME_TASK_CODE_T3 = "time_task_0"
+MODE_DURATION = 0
+MODE_VOLUME = 1
+
+_QUOTA_NOTIFICATION_ID = "xtend_tuya_fdm5kw_cloud_quota"
+
+# Circuit breaker — once the Tuya OpenAPI returns 60001001 ("controllable
+# device pool quota insufficient") we stop hitting the cloud for N hours
+# instead of burning calls that will all fail. The DP write path keeps
+# running so timers still fire locally. Cleared on HA process restart or
+# via `xtend_tuya.fdm5kw_clear_quota_lockout`. The quota is account-wide,
+# so the lockout is module-global (one quota hit on any device blocks all
+# cloud writes for every fdm5kw on the account).
+QUOTA_LOCKOUT_SECONDS = 6 * 3600
+_quota_lockout_until: float = 0.0
+
+
+def _is_quota_locked_out() -> bool:
+    return _quota_lockout_until > time.monotonic()
+
+
+def _engage_quota_lockout() -> None:
+    global _quota_lockout_until
+    _quota_lockout_until = time.monotonic() + QUOTA_LOCKOUT_SECONDS
+    _LOGGER.warning(
+        "fdm5kw cloud-timer lockout engaged for %d s after Tuya quota error",
+        QUOTA_LOCKOUT_SECONDS,
+    )
+
+
+def clear_quota_lockout() -> None:
+    """Manual reset hook for the cloud-timer circuit breaker.
+
+    Wired to `xtend_tuya.fdm5kw_clear_quota_lockout` service. Use after
+    bumping the Tuya IoT-Core plan or freeing devices so the next user
+    action retries the cloud write."""
+    global _quota_lockout_until
+    _quota_lockout_until = 0.0
+    _LOGGER.warning("fdm5kw cloud-timer lockout cleared")
+
+
+def _notify_quota_exceeded(hass) -> None:
+    """Surface the controllable-device quota error as a persistent
+    notification once per HA session. The cloud rejected the timer write
+    but the device DP still saved locally, so we want the user to know
+    *why* SmartLife/cloud sync is degraded without spamming the log on
+    every subsequent write."""
+    try:
+        from homeassistant.components import persistent_notification
+
+        persistent_notification.async_create(
+            hass,
+            TUYA_ERR_DEVICE_POOL_QUOTA_MSG,
+            title="Tuya quota exceeded",
+            notification_id=_QUOTA_NOTIFICATION_ID,
+        )
+    except Exception:
+        _LOGGER.warning("Failed to emit persistent quota notification", exc_info=True)
+
+
+def _handle_cloud_response(hass, op: str, device_id: str, resp: Any) -> None:
+    """Inspect a Tuya OpenAPI response and surface known soft failures.
+    Returns nothing; logging is the contract. Callers continue regardless
+    so the DP write path stays best-effort."""
+    if not isinstance(resp, dict):
+        return
+    code = resp.get("code")
+    if code == TUYA_ERR_DEVICE_POOL_QUOTA:
+        _LOGGER.warning(
+            "Cloud %s for %s hit Tuya quota error %s — %s",
+            op,
+            device_id,
+            code,
+            TUYA_ERR_DEVICE_POOL_QUOTA_MSG,
+        )
+        _engage_quota_lockout()
+        _notify_quota_exceeded(hass)
+
+
+def _days_to_mask(days: list[str] | int | None) -> int:
+    if days is None:
+        return 0
+    if isinstance(days, int):
+        return days & 0x7F
+    mask = 0
+    for d in days:
+        try:
+            mask |= 1 << DAYS_OF_WEEK.index(d.capitalize())
+        except ValueError:
+            _LOGGER.warning("Unknown day %r (expected one of %s)", d, DAYS_OF_WEEK)
+    return mask
+
+
+def _mask_to_loops(mask: int) -> str:
+    return "".join("1" if mask & (1 << i) else "0" for i in range(7))
+
+
+def _mode_to_int(mode: str) -> int:
+    if mode == "duration":
+        return MODE_DURATION
+    if mode == "volume":
+        return MODE_VOLUME
+    raise ValueError(f"mode must be 'duration' or 'volume', got {mode!r}")
+
+
+def build_time_task_payload(
+    slot: int,
+    mode: int,
+    value: int,
+    hour: int,
+    minute: int,
+    days_mask: int,
+    enabled: bool,
+) -> str:
+    """Build base64-encoded 11-byte time_task DP payload.
+
+    Byte layout (verified 2026-06-05 against SmartLife app toggles):
+    [slot, enabled, mode, value(4B BE), hour, minute, days_mask, const=1].
+    byte[1] is the enable flag (1=active, 0=disabled) — SmartLife flips
+    exactly this byte on toggle, keeping the rest of the payload. byte[10]
+    is a constant 1 (NOT the enable flag, as the old spec assumed).
+    """
+    if not 0 <= slot <= 6:
+        raise ValueError(f"slot must be 0–6, got {slot}")
+    payload = bytes(
+        [
+            slot & 0xFF,
+            1 if enabled else 0,
+            mode & 0xFF,
+            (value >> 24) & 0xFF,
+            (value >> 16) & 0xFF,
+            (value >> 8) & 0xFF,
+            value & 0xFF,
+            hour & 0xFF,
+            minute & 0xFF,
+            days_mask & 0x7F,
+            1,
+        ]
+    )
+    return base64.b64encode(payload).decode("ascii")
+
+
+def build_delete_payload(slot: int) -> str:
+    """Build base64 payload that clears a slot (count=0)."""
+    if not 0 <= slot <= 6:
+        raise ValueError(f"slot must be 0–6, got {slot}")
+    return base64.b64encode(bytes([slot] + [0] * 10)).decode("ascii")
+
+
+def build_time_task_payload_t3(
+    index: int,
+    mode: int,
+    value: int,
+    hour: int,
+    minute: int,
+    days_mask: int,
+    enabled: bool,
+) -> str:
+    """Build base64 12-byte time_task_0 DP payload for QT-08W-T3.
+
+    Byte layout (decoded live 2026-07-15, two duration timers on 706):
+    [00, index, index, mode, value(4B BE), hour, minute, days_mask, enabled].
+    byte[1] is the per-timer index (NOT byte[0] as on old valves); byte[2]
+    mirrors the index in SmartLife's own writes; mode 0=duration(s)/1=vol(L),
+    days bit0=Mon. A raw write of this shape applied on-device (48 s echo,
+    cloud didn't roll back) — see t3_valve_dp_decode memory.
+    """
+    if not 0 <= index <= 6:
+        raise ValueError(f"index must be 0–6, got {index}")
+    payload = bytes(
+        [
+            0,
+            index & 0xFF,
+            index & 0xFF,
+            mode & 0xFF,
+            (value >> 24) & 0xFF,
+            (value >> 16) & 0xFF,
+            (value >> 8) & 0xFF,
+            value & 0xFF,
+            hour & 0xFF,
+            minute & 0xFF,
+            days_mask & 0x7F,
+            1 if enabled else 0,
+        ]
+    )
+    return base64.b64encode(payload).decode("ascii")
+
+
+def build_delete_payload_t3(index: int) -> str:
+    """Clear a T3 slot: all-zero 12-byte payload at the given index. index 0
+    is the all-zeros frame confirmed to clear on 706 (2026-07-15)."""
+    if not 0 <= index <= 6:
+        raise ValueError(f"index must be 0–6, got {index}")
+    return base64.b64encode(bytes([0, index] + [0] * 10)).decode("ascii")
+
+
+def _is_t3(hass, device_id: str) -> bool:
+    """T3 valve = carries the `time_task_0` DP. Detected from live status."""
+    mm = _find_multi_manager(hass, device_id)
+    if mm is None:
+        return False
+    device = mm.device_map.get(device_id)
+    if device is None:
+        return False
+    return device.status.get(TIME_TASK_CODE_T3) is not None
+
+
+def _find_multi_manager(hass, device_id: str) -> MultiManager | None:
+    for mm in get_all_multi_managers(hass):
+        if mm.device_map.get(device_id):
+            return mm
+    return None
+
+
+def _find_iot_account(hass, device_id: str) -> Any:
+    """Return the OpenAPI (tuya_iot) account for the device, or None."""
+    for mm in get_all_multi_managers(hass):
+        if mm.device_map.get(device_id):
+            return mm.get_account_by_name("tuya_iot")
+    return None
+
+
+def _get_prior_slot(hass, device_id: str, slot: int) -> dict | None:
+    """Look up the current slot data from the registry entity so we can
+    match it against the cloud timer registry when deleting/overwriting.
+    Returns None if the entity isn't loaded yet or the slot is empty."""
+    # Local import avoids a circular import at module load time.
+    from .sensor import DPCodeTimeTaskRegistryWrapper, Fdm5kwTimerRegistryEntity
+
+    entity = Fdm5kwTimerRegistryEntity.INSTANCES.get(device_id)
+    if entity is None:
+        return None
+    wrapper = entity._dpcode_wrapper
+    if not isinstance(wrapper, DPCodeTimeTaskRegistryWrapper):
+        return None
+    return wrapper.slots.get(slot)
+
+
+async def _write_time_task(
+    multi_manager: MultiManager,
+    device_id: str,
+    b64_value: str,
+    code: str = TIME_TASK_CODE,
+) -> bool:
+    commands = [{"code": code, "value": b64_value}]
+    try:
+        ok = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+            multi_manager.send_commands, device_id, commands
+        )
+    except Exception:
+        _LOGGER.exception("time_task DP write failed for %s", device_id)
+        return False
+    if not ok:
+        _LOGGER.warning("time_task DP write rejected for %s", device_id)
+        return False
+    return True
+
+
+def _ha_timezone(hass) -> tuple[str, str]:
+    """Return (timezone_id, '+H:MM' utc offset) for HA's configured TZ."""
+    from datetime import datetime
+    try:
+        import zoneinfo
+    except ImportError:  # pragma: no cover
+        from backports import zoneinfo  # type: ignore
+
+    tz_name = getattr(hass.config, "time_zone", None) or "UTC"
+    try:
+        tz = zoneinfo.ZoneInfo(tz_name)
+    except (zoneinfo.ZoneInfoNotFoundError, ValueError):
+        tz = zoneinfo.ZoneInfo("UTC")
+    offset = datetime.now(tz).utcoffset()
+    if offset is None:
+        return tz_name, "+0:00"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    return tz_name, f"{sign}{total_minutes // 60}:{total_minutes % 60:02d}"
+
+
+async def _post_cloud_timer(
+    hass,
+    account,
+    device_id: str,
+    hour: int,
+    minute: int,
+    days_mask: int,
+    mode: int,
+    value: int,
+    enabled: bool,
+    code: str = TIME_TASK_CODE,
+) -> None:
+    """Cloud timer create so the cloud doesn't roll back our DP write.
+    Schema (verified 2026-05-12 against live hardware, fdm5kw category):
+    - top-level: category, loops, timezone_id, time_zone, instruct
+    - each instruct[]: time (HH:mm), functions [{code, value}]
+    The GET response renders the same data with a different layout
+    (timer rows nested under groups). Do NOT mirror the GET shape on POST.
+    """
+    if _is_quota_locked_out():
+        _LOGGER.warning(
+            "Cloud timer POST skipped for %s — quota lockout active (DP-only)",
+            device_id,
+        )
+        return
+    time_str = f"{hour:02d}:{minute:02d}"
+    loops = _mask_to_loops(days_mask)
+    start_time_sec = hour * 3600 + minute * 60
+    # SmartLife's scheduler UI requires the rich `value` shape — verified
+    # against a live account on 2026-05-12. A minimal body still
+    # gets stored, but SL renders it as a half-broken "Single watering"
+    # entry and its edit flow hangs.
+    func_value = {
+        "startTimeStr": time_str,
+        "loops": loops,
+        "duration": value if mode == MODE_DURATION else 0,
+        "capacity": value if mode == MODE_VOLUME else 0,
+        "startTime": start_time_sec,
+        "start": True,
+        "current": 0,
+    }
+    timezone_id, time_zone = _ha_timezone(hass)
+    body = json.dumps(
+        {
+            "category": "timer",
+            "loops": loops,
+            "timezone_id": timezone_id,
+            "time_zone": time_zone,
+            "instruct": [
+                {
+                    "time": time_str,
+                    "date": "00000000",
+                    "functions": [{"code": code, "value": func_value}],
+                }
+            ],
+        }
+    )
+    url = f"/v1.0/devices/{device_id}/timers"
+    _LOGGER.warning(
+        "Cloud timer POST -> %s body=%s account_type=%s",
+        url,
+        body,
+        type(account).__name__,
+    )
+    try:
+        resp = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+            account.call_api, "POST", url, body
+        )
+    except Exception:
+        _LOGGER.warning(
+            "Cloud timer POST raised for %s (non-fatal)", device_id, exc_info=True
+        )
+        return
+    _LOGGER.warning("Cloud timer POST response for %s: %s", device_id, resp)
+    _handle_cloud_response(hass, "POST", device_id, resp)
+    if not resp or not resp.get("success"):
+        _LOGGER.warning(
+            "Cloud timer POST returned no success for %s: %s", device_id, resp
+        )
+
+
+async def _delete_cloud_timer_by_match(
+    hass, account, device_id: str, hour: int, minute: int, days_mask: int
+) -> None:
+    """List cloud timers, delete the one matching time+days. Best-effort."""
+    if _is_quota_locked_out():
+        _LOGGER.warning(
+            "Cloud timer GET/DELETE skipped for %s — quota lockout active",
+            device_id,
+        )
+        return
+    list_url = f"/v1.0/devices/{device_id}/timers"
+    _LOGGER.warning(
+        "Cloud timer GET -> %s (match %02d:%02d mask=%d)",
+        list_url,
+        hour,
+        minute,
+        days_mask,
+    )
+    try:
+        resp = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+            account.call_api, "GET", list_url, None
+        )
+    except Exception:
+        _LOGGER.warning(
+            "Cloud timer list raised for %s (non-fatal)", device_id, exc_info=True
+        )
+        return
+    _LOGGER.warning("Cloud timer GET response for %s: %s", device_id, resp)
+    _handle_cloud_response(hass, "GET", device_id, resp)
+    if not resp or not resp.get("success"):
+        _LOGGER.warning(
+            "Cloud timer GET non-success for %s, skipping delete", device_id
+        )
+        return
+    time_str = f"{hour:02d}:{minute:02d}"
+    loops = _mask_to_loops(days_mask)
+    matched = False
+    for category in resp.get("result", []):
+        for group in category.get("groups", []):
+            for timer in group.get("timers", []):
+                # Prefer the top-level time/loops — always present, including
+                # T3 app-created timers whose `functions` list comes back empty.
+                funcs = timer.get("functions") or []
+                v = funcs[0].get("value", {}) if funcs else {}
+                t_time = timer.get("time") or v.get("startTimeStr")
+                t_loops = timer.get("loops") or v.get("loops")
+                if t_time == time_str and t_loops == loops:
+                    # Tuya's selective timer delete takes the timer-group
+                    # id as a *query-string* parameter; both path-style
+                    # variants (/timers/{group_id}, /timer/group/{id}, …)
+                    # return 1108 "uri path invalid". Verified against the
+                    # live account on 2026-05-12 with a throwaway
+                    # group: DELETE /timers?group_id=<gid> succeeds and
+                    # only removes that group.
+                    group_id = group.get("id")
+                    if not group_id:
+                        continue
+                    matched = True
+                    del_url = f"/v1.0/devices/{device_id}/timers?group_id={group_id}"
+                    _LOGGER.warning("Cloud timer DELETE -> %s", del_url)
+                    try:
+                        del_resp = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+                            account.call_api, "DELETE", del_url, None
+                        )
+                        _LOGGER.warning(
+                            "Cloud timer DELETE response for %s: %s",
+                            device_id,
+                            del_resp,
+                        )
+                        _handle_cloud_response(hass, "DELETE", device_id, del_resp)
+                    except Exception:
+                        _LOGGER.warning(
+                            "Cloud timer DELETE raised for %s (non-fatal)",
+                            device_id,
+                            exc_info=True,
+                        )
+    if not matched:
+        _LOGGER.warning(
+            "Cloud timer no entries matched %s for %s", time_str, device_id
+        )
+
+
+async def set_timer(hass, data: dict) -> bool:
+    device_id: str = data["device_id"]
+    slot: int = int(data["slot"])
+    hour: int = int(data["hour"])
+    minute: int = int(data["minute"])
+    mode: int = _mode_to_int(data.get("mode", "duration"))
+    value: int = int(data["value"])
+    days_mask: int = _days_to_mask(data.get("days"))
+    enabled: bool = bool(data.get("enabled", True))
+
+    multi_manager = _find_multi_manager(hass, device_id)
+    if multi_manager is None:
+        _LOGGER.error("No multi_manager found for device %s", device_id)
+        return False
+
+    # When this is an edit (not a create), look up the prior slot state so
+    # we can delete the cloud entry that's about to be replaced. Avoids
+    # duplicate SmartLife timer entries after time/day changes.
+    prior = _get_prior_slot(hass, device_id, slot)
+
+    # T3 valves carry the indexed 12-byte `time_task_0` DP; everything else
+    # (cloud dual-write, prior-delete, disabled-skip) is identical — the cloud
+    # POST just uses the `time_task_0` function code. Verified 2026-07-15:
+    # POST /timers with code time_task_0 renders back on GET; DP write applies
+    # and the cloud doesn't roll it back.
+    is_t3 = _is_t3(hass, device_id)
+    task_code = TIME_TASK_CODE_T3 if is_t3 else TIME_TASK_CODE
+    if is_t3:
+        b64 = build_time_task_payload_t3(
+            slot, mode, value, hour, minute, days_mask, enabled
+        )
+    else:
+        b64 = build_time_task_payload(
+            slot, mode, value, hour, minute, days_mask, enabled
+        )
+    if not await _write_time_task(multi_manager, device_id, b64, code=task_code):
+        return False
+
+    account = _find_iot_account(hass, device_id)
+    if account is None:
+        _LOGGER.warning(
+            "set_timer: no tuya_iot account for %s (DP write only, cloud may roll back)",
+            device_id,
+        )
+        return True
+    _LOGGER.warning(
+        "set_timer: tuya_iot account found for %s (type=%s), proceeding to cloud write",
+        device_id,
+        type(account).__name__,
+    )
+
+    if prior is not None:
+        _LOGGER.warning(
+            "set_timer: prior slot %d for %s = %s, deleting cloud match first",
+            slot,
+            device_id,
+            prior,
+        )
+        await _delete_cloud_timer_by_match(
+            hass,
+            account,
+            device_id,
+            int(prior.get("hour", hour)),
+            int(prior.get("minute", minute)),
+            int(prior.get("days_mask", days_mask)),
+        )
+
+    # Tuya's OpenAPI has no per-timer enable/disable toggle (PUT
+    # /timers/groups/{gid}/status is rejected with 1108; PUT on the
+    # group body ignores `status` and resets it to 1). The closest
+    # equivalent: when HA marks the timer disabled, leave it out of
+    # the cloud registry entirely so the cloud can't fire it. The
+    # device DP still carries the disabled bit for offline execution.
+    # Net effect in SmartLife: the entry disappears from the schedule
+    # tab when disabled and reappears on re-enable. Verified
+    # 2026-05-12.
+    if not enabled:
+        _LOGGER.warning(
+            "set_timer: enabled=False for slot %d on %s — skipping cloud POST "
+            "so SmartLife schedule doesn't fire (no API to keep a disabled entry)",
+            slot,
+            device_id,
+        )
+        return True
+
+    await _post_cloud_timer(
+        hass, account, device_id, hour, minute, days_mask, mode, value, enabled,
+        code=task_code,
+    )
+    return True
+
+
+async def _get_cloud_timer_keys(account, device_id: str) -> set[tuple[str, str]] | None:
+    """GET the cloud timer registry and return the set of (time_str, loops)
+    keys it holds. Read-only — draws the 26k/mo API-call pool, NOT the
+    10-controllable-device cap. Returns None if the GET failed (so callers
+    don't mistake an API failure for an empty cloud registry and wipe every
+    HA slot as a ghost)."""
+    list_url = f"/v1.0/devices/{device_id}/timers"
+    try:
+        resp = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+            account.call_api, "GET", list_url, None
+        )
+    except Exception:
+        _LOGGER.warning(
+            "resync: cloud timer GET raised for %s (non-fatal)", device_id, exc_info=True
+        )
+        return None
+    if not resp or not resp.get("success"):
+        _LOGGER.warning("resync: cloud timer GET non-success for %s: %s", device_id, resp)
+        return None
+    keys: set[tuple[str, str]] = set()
+    for category in resp.get("result", []):
+        for group in category.get("groups", []):
+            for timer in group.get("timers", []):
+                # Top-level time/loops first — T3 app timers report empty
+                # `functions`, so keying off the value dict alone would miss
+                # them and (in resync) flag every enabled slot as an orphan.
+                funcs = timer.get("functions") or []
+                v = funcs[0].get("value", {}) if funcs else {}
+                t = timer.get("time") or v.get("startTimeStr")
+                loops = timer.get("loops") or v.get("loops")
+                if t is not None and loops is not None:
+                    keys.add((t, loops))
+    return keys
+
+
+async def resync_from_cloud(hass, data: dict) -> dict:
+    """Reconcile the HA timer registry against the Tuya cloud, clearing the
+    live orphan (zombie) slots the cloud no longer knows about.
+
+    A *live orphan* = an ENABLED HA slot with no matching cloud timer. Enabled
+    timers are always cloud-posted (`set_timer` posts on enable), so a missing
+    cloud entry means the cloud rolled back / a SmartLife delete left the
+    device slot live — it WILL water offline with no cloud entry (the 969
+    04:20 case). Clear the device slot: a control write, 1 unit against the
+    10/valve/month cap for this account.
+
+    DISABLED slots are deliberately left alone. `set_timer` never posts a
+    disabled timer to the cloud, so a legitimately user-disabled timer is
+    indistinguishable from a disabled ghost by cloud state alone — dropping it
+    would delete a real timer the user just toggled off. Disabled ghosts don't
+    fire, so they're harmless clutter; leave manual cleanup for those.
+
+    Read-first by construction: the GET is always free against the control
+    cap; a write happens only per live orphan found. User-triggered per valve,
+    so it can't runaway the quota the way a periodic sweep would."""
+    device_id: str = data["device_id"]
+    is_t3 = _is_t3(hass, device_id)
+
+    account = _find_iot_account(hass, device_id)
+    if account is None:
+        _LOGGER.warning("resync: no tuya_iot account for %s — cannot reconcile", device_id)
+        return {"success": False, "error": "no_cloud_account"}
+
+    from .sensor import Fdm5kwTimerRegistryEntity
+
+    entity = Fdm5kwTimerRegistryEntity.INSTANCES.get(device_id)
+    if entity is None:
+        _LOGGER.warning("resync: no timer registry entity loaded for %s", device_id)
+        return {"success": False, "error": "no_registry_entity"}
+    wrapper = entity._dpcode_wrapper
+    slots: dict = getattr(wrapper, "slots", None)
+    if slots is None:
+        return {"success": False, "error": "no_registry_slots"}
+
+    cloud_keys = await _get_cloud_timer_keys(account, device_id)
+    if cloud_keys is None:
+        return {"success": False, "error": "cloud_get_failed"}
+
+    multi_manager = _find_multi_manager(hass, device_id)
+    locked_out = _is_quota_locked_out()
+
+    checked = orphans_cleared = orphans_deferred = 0
+    for slot_idx, s in list(slots.items()):
+        if not s:
+            continue
+        checked += 1
+        # Only enabled slots are judged — disabled ones are never in the cloud
+        # by design (see docstring), so "no cloud match" tells us nothing.
+        if not s.get("enabled"):
+            continue
+        key = (
+            f"{int(s.get('hour', 0)):02d}:{int(s.get('minute', 0)):02d}",
+            _mask_to_loops(int(s.get("days_mask", 0))),
+        )
+        if key in cloud_keys:
+            continue  # legit — cloud agrees it exists
+        # Live orphan — fires offline with no cloud entry. Needs a device slot
+        # clear (control write). Skip if quota-locked; the write would just
+        # fail, so report it deferred rather than burn a call.
+        if locked_out or multi_manager is None:
+            orphans_deferred += 1
+            _LOGGER.warning(
+                "resync: live orphan slot %d on %s left in place (quota lockout / no manager)",
+                slot_idx, device_id,
+            )
+            continue
+        clear_payload = (
+            build_delete_payload_t3(slot_idx) if is_t3
+            else build_delete_payload(slot_idx)
+        )
+        clear_code = TIME_TASK_CODE_T3 if is_t3 else TIME_TASK_CODE
+        if await _write_time_task(
+            multi_manager, device_id, clear_payload, code=clear_code
+        ):
+            slots[slot_idx] = None
+            orphans_cleared += 1
+            _LOGGER.warning(
+                "resync: cleared live orphan slot %d on %s (no cloud entry)",
+                slot_idx, device_id,
+            )
+        else:
+            orphans_deferred += 1
+
+    if orphans_cleared:
+        entity.async_write_ha_state()
+
+    result = {
+        "success": True,
+        "checked": checked,
+        "orphans_cleared": orphans_cleared,
+        "orphans_deferred": orphans_deferred,
+    }
+    _LOGGER.warning("resync %s: %s", device_id, result)
+    return result
+
+
+async def delete_timer(hass, data: dict) -> bool:
+    device_id: str = data["device_id"]
+    slot: int = int(data["slot"])
+
+    multi_manager = _find_multi_manager(hass, device_id)
+    if multi_manager is None:
+        _LOGGER.error("No multi_manager found for device %s", device_id)
+        return False
+
+    # Capture the slot's current time/days BEFORE we wipe the DP so we can
+    # match the cloud timer entry on the way out.
+    prior = _get_prior_slot(hass, device_id, slot)
+    _LOGGER.warning(
+        "delete_timer: device=%s slot=%d prior=%s", device_id, slot, prior
+    )
+
+    # T3 uses the indexed 12-byte clear + time_task_0 code; the cloud
+    # delete-by-match below is code-agnostic (matches on time/loops).
+    is_t3 = _is_t3(hass, device_id)
+    if is_t3:
+        b64 = build_delete_payload_t3(slot)
+        task_code = TIME_TASK_CODE_T3
+    else:
+        b64 = build_delete_payload(slot)
+        task_code = TIME_TASK_CODE
+    if not await _write_time_task(multi_manager, device_id, b64, code=task_code):
+        return False
+
+    account = _find_iot_account(hass, device_id)
+    if account is None:
+        _LOGGER.warning(
+            "delete_timer: no tuya_iot account for %s (DP-only delete)", device_id
+        )
+        return True
+    if prior is None:
+        _LOGGER.warning(
+            "delete_timer: no prior slot data for %s slot %d — cannot match cloud entry",
+            device_id,
+            slot,
+        )
+        return True
+
+    await _delete_cloud_timer_by_match(
+        hass,
+        account,
+        device_id,
+        int(prior.get("hour", 0)),
+        int(prior.get("minute", 0)),
+        int(prior.get("days_mask", 0)),
+    )
+    return True

--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_iot/init.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_iot/init.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import requests
 import json
 from datetime import datetime, timedelta
@@ -324,6 +325,34 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
             if device.id not in self.multi_manager.devices_shared:
                 self.multi_manager.devices_shared[device.id] = device
 
+    async def _safe_subscription_test(self, callback, *args) -> bool:
+        """Run a best-effort OpenAPI subscription probe without ever failing setup.
+
+        These probes only decide whether to raise a non-critical "not
+        subscribed" warning. A slow relay call here used to hang setup long
+        enough to be cancelled (asyncio.CancelledError), taking the whole
+        entry down. It only bit accounts that actually own the probed device
+        types (sockets, cameras), so it looked intermittent across hubs on
+        the same install. Bound each probe with a timeout and swallow any
+        error, returning True so no spurious issue is raised and setup
+        always continues. A genuine task cancellation (shutdown) still
+        propagates because CancelledError is a BaseException, not caught here.
+        """
+        try:
+            return await asyncio.wait_for(
+                XTEventLoopProtector.execute_out_of_event_loop_and_return(
+                    callback, *args
+                ),
+                timeout=15,
+            )
+        except Exception as exc:  # noqa: BLE001 - probe is best-effort
+            LOGGER.debug(
+                "Subscription probe %s skipped (%s)",
+                getattr(callback, "__name__", callback),
+                exc,
+            )
+            return True
+
     async def on_loading_finalized(
         self,
         hass: HomeAssistant,
@@ -337,11 +366,9 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
         ):
             # Verify if we are subscribed to the lock service
             if device := multi_manager.device_map.get(lock_device_id, None):
-                test_api = (
-                    await XTEventLoopProtector.execute_out_of_event_loop_and_return(
-                        self.iot_account.device_manager.test_lock_api_subscription,
-                        device,
-                    )
+                test_api = await self._safe_subscription_test(
+                    self.iot_account.device_manager.test_lock_api_subscription,
+                    device,
                 )
                 if not test_api:
                     self.multi_manager.raise_issue(
@@ -360,11 +387,9 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
         ):
             # Verify if we are subscribed to the lock service
             if device := multi_manager.device_map.get(camera_device_id, None):
-                test_api = (
-                    await XTEventLoopProtector.execute_out_of_event_loop_and_return(
-                        self.iot_account.device_manager.test_camera_api_subscription,
-                        device,
-                    )
+                test_api = await self._safe_subscription_test(
+                    self.iot_account.device_manager.test_camera_api_subscription,
+                    device,
                 )
                 if not test_api:
                     self.multi_manager.raise_issue(
@@ -384,10 +409,9 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
         ):
             # Verify if we are subscribed to the lock service
             if device := multi_manager.device_map.get(ir_hub_device_id, None):
-                test_api = (
-                    await XTEventLoopProtector.execute_out_of_event_loop_and_return(
-                        self.iot_account.device_manager.test_ir_api_subscription, device
-                    )
+                test_api = await self._safe_subscription_test(
+                    self.iot_account.device_manager.test_ir_api_subscription,
+                    device,
                 )
                 if not test_api:
                     self.multi_manager.raise_issue(
@@ -408,7 +432,7 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
             # Verify if we are subscribed to the energy statistic service
             for device_id in energy_sensor_entities:
                 if device := multi_manager.device_map.get(device_id, None):
-                    test_api = await XTEventLoopProtector.execute_out_of_event_loop_and_return(
+                    test_api = await self._safe_subscription_test(
                         self.iot_account.device_manager.test_sensor_energy_statistic_api_subscription,
                         device,
                     )
@@ -713,6 +737,8 @@ class XTTuyaIOTDeviceManagerInterface(XTDeviceManagerInterface):
                 return self.iot_account.device_manager.api.get(url, params)
             case "POST":
                 return self.iot_account.device_manager.api.post(url, params)
+            case "DELETE":
+                return self.iot_account.device_manager.api.delete(url, params)
         return None
 
     def get_webrtc_sdp_answer(

--- a/custom_components/xtend_tuya/multi_manager/multi_manager.py
+++ b/custom_components/xtend_tuya/multi_manager/multi_manager.py
@@ -25,6 +25,7 @@ from ..const import (
     XTIRRemoteInformation,
     XTIRRemoteKeysInformation,
     XTLockingMechanism,
+    MESSAGE_SOURCE_TUYA_IOT,
     MESSAGE_SOURCE_TUYA_SHARING,
     XTDeviceWatcherCategory,
     XT_DEVICE_EVENT_NOTIFY_DPCODE,
@@ -84,6 +85,7 @@ from .shared.storage.storage_manager import (
     XTStorageManager,
 )
 import custom_components.xtend_tuya.multi_manager.shared.data_entry.shared_data_entry as shared_data_entry
+from .shared.quota import ControllableQuotaTracker
 
 
 class MultiManager(TuyaManager):
@@ -100,6 +102,9 @@ class MultiManager(TuyaManager):
         self.device_watcher = DeviceWatcher(self)
         self.storage_manager = XTStorageManager(hass, config_entry, self)
         self.accounts: dict[str, XTDeviceManagerInterface] = {}
+        # Per-hub OpenAPI controllable-device quota tracker (created in
+        # setup_entry only for hubs that have a tuya_iot account).
+        self.controllable_quota: ControllableQuotaTracker | None = None
         self.master_device_map: XTDeviceMap = XTDeviceMap({})
         self.is_ready_for_messages = False
         self.pending_messages: list[tuple[str, dict]] = []
@@ -173,6 +178,22 @@ class MultiManager(TuyaManager):
         for account in self.accounts.values():
             await XTEventLoopProtector.execute_out_of_event_loop_and_return(
                 account.on_post_setup
+            )
+        # Controllable-device quota tracker, one per hub. Each xtend hub maps to
+        # one Tuya cloud project with a free-tier cap of 10 controllable devices
+        # per calendar month. We count every device this hub successfully sends a
+        # command to via send_commands. Commands issued from the SmartLife app go
+        # through Tuya's app cloud and never reach send_commands, so they are
+        # naturally excluded; reads don't go through send_commands either. The
+        # hub key is the config entry id (the OpenAPI access_id is not reliably in
+        # config_entry.options in practice — it lives in xtend storage).
+        hub_id = self.config_entry.entry_id
+        self.controllable_quota = ControllableQuotaTracker(self.hass, hub_id)
+        try:
+            await self.controllable_quota.async_load()
+        except Exception:  # noqa: BLE001 - a corrupt quota store must never break hub setup
+            LOGGER.warning(
+                "Failed to load controllable-quota store for hub %s", hub_id
             )
 
     async def setup_entity_parsers(self) -> None:
@@ -528,6 +549,23 @@ class MultiManager(TuyaManager):
             return_list = append_lists(return_list, account.query_scenes())
         return return_list
 
+    def _note_controllable_command(self, account, device_id: str) -> None:
+        """Count a successful command toward this hub's controllable-device cap.
+
+        Only commands that actually went out over an OpenAPI (tuya_iot)
+        account consume the cloud project's monthly controllable-device
+        allowance. A hub commonly also holds a tuya_sharing account, and
+        commands served by that one travel the Smart Life pathway and cost
+        nothing against the project quota, so counting them would overstate
+        usage and could trip the warning while the real allowance is
+        untouched. Thread-safe — send_commands runs in an executor.
+        """
+        if self.controllable_quota is None:
+            return
+        if account is None or account.get_type_name() != MESSAGE_SOURCE_TUYA_IOT:
+            return
+        self.controllable_quota.record(device_id)
+
     def send_commands(self, device_id: str, commands: list[dict[str, Any]]) -> bool:  # type: ignore
         virtual_function_commands: list[dict[str, Any]] = []
         regular_commands: list[dict[str, Any]] = []
@@ -572,6 +610,7 @@ class MultiManager(TuyaManager):
                     if last_command_result := account.send_command(
                         device_id, regular_command, reverse_filters=False
                     ):
+                        self._note_controllable_command(account, device_id)
                         break
 
                 # If the command failed, try using the other APIs
@@ -580,6 +619,7 @@ class MultiManager(TuyaManager):
                         if last_command_result := account.send_command(
                             device_id, regular_command, reverse_filters=True
                         ):
+                            self._note_controllable_command(account, device_id)
                             break
 
                 # If it still didn't work, try sending the command aliases if they exist
@@ -599,11 +639,13 @@ class MultiManager(TuyaManager):
                             if last_command_result := account.send_command(
                                 device_id, command, reverse_filters=False
                             ):
+                                self._note_controllable_command(account, device_id)
                                 break
                         for account in self.accounts.values():
                             if last_command_result := account.send_command(
                                 device_id, command, reverse_filters=True
                             ):
+                                self._note_controllable_command(account, device_id)
                                 break
                         if last_command_result is True:
                             break

--- a/custom_components/xtend_tuya/multi_manager/shared/quota.py
+++ b/custom_components/xtend_tuya/multi_manager/shared/quota.py
@@ -1,0 +1,173 @@
+"""Controllable-device quota tracking for OpenAPI (tuya_iot) hubs.
+
+A Tuya free / Trial IoT-Core project can *monitor* 50 devices but only
+*control* 10 distinct devices per calendar month — every device the project
+sends a command to consumes one unit of that allowance, which refreshes on the
+1st. Reads do not count. There is no Tuya endpoint that reports the current
+usage, so we count it ourselves: whenever the integration successfully issues a
+command through a hub's ``tuya_iot`` (OpenAPI) account, we record the target
+device id in a per-hub, per-month set. The size of that set is the number of
+controllable units used this month.
+
+Commands issued from the SmartLife app go through Tuya's app cloud (a different
+credential) and do not consume this project's allowance, so they are correctly
+NOT counted here — only commands this integration sends via our OpenAPI keys.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.storage import Store
+
+_LOGGER = logging.getLogger(__name__)
+
+STORE_VERSION = 1
+# Tuya Trial Edition cap. Kept here as a constant; bump if a hub is on a paid
+# plan with a higher controllable allowance.
+DEFAULT_CONTROLLABLE_LIMIT = 10
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _month_key(now: dt.datetime | None = None) -> str:
+    now = now or _utcnow()
+    return f"{now.year:04d}-{now.month:02d}"
+
+
+def _next_reset(now: dt.datetime | None = None) -> str:
+    now = now or _utcnow()
+    year = now.year + (1 if now.month == 12 else 0)
+    month = 1 if now.month == 12 else now.month + 1
+    return f"{year:04d}-{month:02d}-01"
+
+
+class ControllableQuotaTracker:
+    """Per-hub monthly distinct-device counter for the OpenAPI controllable cap."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        hub_id: str,
+        limit: int = DEFAULT_CONTROLLABLE_LIMIT,
+    ) -> None:
+        self.hass = hass
+        self.hub_id = hub_id
+        self.limit = limit
+        self._month = _month_key()
+        self._devices: set[str] = set()
+        self._store: Store = Store(hass, STORE_VERSION, f"xtend_tuya_quota_{hub_id}")
+        self._listeners: list = []
+
+    async def async_load(self) -> None:
+        data = await self._store.async_load()
+        if isinstance(data, dict) and data.get("month") == _month_key():
+            self._month = data["month"]
+            self._devices = set(data.get("devices", []))
+        else:
+            # Empty store or a stale month -> start the current month fresh.
+            self._month = _month_key()
+            self._devices = set()
+            await self._async_save()
+
+    async def _async_save(self) -> None:
+        await self._store.async_save(
+            {"month": self._month, "devices": sorted(self._devices)}
+        )
+
+    def _roll_month_if_needed(self) -> bool:
+        cur = _month_key()
+        if cur != self._month:
+            self._month = cur
+            self._devices = set()
+            return True
+        return False
+
+    def record(self, device_id: str) -> None:
+        """Record a successful OpenAPI command to ``device_id``.
+
+        Thread-safe: called from the executor thread that runs send_commands.
+        Persisting and notifying entities are bounced onto the event loop.
+        """
+        rolled = self._roll_month_if_needed()
+        is_new = device_id not in self._devices
+        if is_new:
+            self._devices.add(device_id)
+        if is_new or rolled:
+            self.hass.add_job(self._async_save)
+            self._notify_threadsafe()
+
+    # ----- derived values (read on the event loop) -----
+
+    @property
+    def used(self) -> int:
+        self._roll_month_if_needed()
+        return len(self._devices)
+
+    @property
+    def remaining(self) -> int:
+        return max(0, self.limit - self.used)
+
+    @property
+    def devices(self) -> list[str]:
+        return sorted(self._devices)
+
+    @property
+    def reset_date(self) -> str:
+        return _next_reset()
+
+    # ----- listener plumbing for the sensor -----
+
+    def add_listener(self, cb) -> None:
+        self._listeners.append(cb)
+
+    def remove_listener(self, cb) -> None:
+        if cb in self._listeners:
+            self._listeners.remove(cb)
+
+    def _notify_threadsafe(self) -> None:
+        for cb in list(self._listeners):
+            self.hass.add_job(cb)
+
+
+class XTControllableQuotaSensor(SensorEntity):
+    """Hub-level sensor: distinct devices controlled via OpenAPI this month."""
+
+    _attr_has_entity_name = False
+    _attr_icon = "mdi:counter"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_should_poll = False
+
+    def __init__(self, tracker: ControllableQuotaTracker, hub_label: str) -> None:
+        self._tracker = tracker
+        self._attr_unique_id = f"xt_controllable_quota_{tracker.hub_id}"
+        self._attr_name = f"Controllable devices used ({hub_label})"
+        self._attr_translation_key = "controllable_quota"
+
+    async def async_added_to_hass(self) -> None:
+        self._tracker.add_listener(self.async_write_ha_state)
+
+    async def async_will_remove_from_hass(self) -> None:
+        self._tracker.remove_listener(self.async_write_ha_state)
+
+    @property
+    def native_value(self) -> int:
+        return self._tracker.used
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        return {
+            "limit": self._tracker.limit,
+            "remaining": self._tracker.remaining,
+            "reset_date": self._tracker.reset_date,
+            "devices": self._tracker.devices,
+            "hub_id": self._tracker.hub_id,
+        }

--- a/custom_components/xtend_tuya/multi_manager/shared/services/services.py
+++ b/custom_components/xtend_tuya/multi_manager/shared/services/services.py
@@ -23,6 +23,7 @@ from ....util import (
 from homeassistant.const import (
     CONF_DEVICE_ID,
 )
+from homeassistant.core import SupportsResponse
 
 CONF_SOURCE = "source"
 CONF_STREAM_TYPE = "stream_type"
@@ -80,6 +81,57 @@ SERVICE_WEBRTC_DEBUG_SCHEMA = vol.Schema(
     }
 )
 
+SERVICE_FDM5KW_SET_TIMER = "fdm5kw_set_timer"
+SERVICE_FDM5KW_SET_TIMER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Required("slot"): vol.All(cv.positive_int, vol.Range(min=0, max=6)),
+        vol.Required("hour"): vol.All(cv.positive_int, vol.Range(min=0, max=23)),
+        vol.Required("minute"): vol.All(cv.positive_int, vol.Range(min=0, max=59)),
+        vol.Required("mode"): vol.In(["duration", "volume"]),
+        vol.Required("value"): cv.positive_int,
+        vol.Optional("days"): vol.Any([cv.string], cv.positive_int),
+        vol.Optional("enabled", default=True): cv.boolean,
+    }
+)
+
+SERVICE_FDM5KW_DELETE_TIMER = "fdm5kw_delete_timer"
+SERVICE_FDM5KW_DELETE_TIMER_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Required("slot"): vol.All(cv.positive_int, vol.Range(min=0, max=6)),
+        vol.Optional("hour"): vol.All(cv.positive_int, vol.Range(min=0, max=23)),
+        vol.Optional("minute"): vol.All(cv.positive_int, vol.Range(min=0, max=59)),
+        vol.Optional("days"): vol.Any([cv.string], cv.positive_int),
+    }
+)
+
+SERVICE_FDM5KW_START_WATERING = "fdm5kw_start_watering"
+SERVICE_FDM5KW_START_WATERING_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Required("mode"): vol.In(["duration", "volume"]),
+        vol.Required("value"): cv.positive_int,
+    }
+)
+
+SERVICE_FDM5KW_STOP_WATERING = "fdm5kw_stop_watering"
+SERVICE_FDM5KW_STOP_WATERING_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+    }
+)
+
+SERVICE_FDM5KW_CLEAR_QUOTA_LOCKOUT = "fdm5kw_clear_quota_lockout"
+SERVICE_FDM5KW_CLEAR_QUOTA_LOCKOUT_SCHEMA = vol.Schema({})
+
+SERVICE_FDM5KW_RESYNC_TIMERS = "fdm5kw_resync_timers"
+SERVICE_FDM5KW_RESYNC_TIMERS_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_DEVICE_ID): cv.string,
+    }
+)
+
 
 class ServiceManager:
     def __init__(self, multi_manager: mm.MultiManager) -> None:
@@ -132,6 +184,63 @@ class ServiceManager:
             True,
             False,
         )
+        self._register_service(
+            DOMAIN,
+            SERVICE_FDM5KW_SET_TIMER,
+            self._handle_fdm5kw_set_timer,
+            SERVICE_FDM5KW_SET_TIMER_SCHEMA,
+            True,
+            True,
+            False,
+        )
+        self._register_service(
+            DOMAIN,
+            SERVICE_FDM5KW_DELETE_TIMER,
+            self._handle_fdm5kw_delete_timer,
+            SERVICE_FDM5KW_DELETE_TIMER_SCHEMA,
+            True,
+            True,
+            False,
+        )
+        self._register_service(
+            DOMAIN,
+            SERVICE_FDM5KW_START_WATERING,
+            self._handle_fdm5kw_start_watering,
+            SERVICE_FDM5KW_START_WATERING_SCHEMA,
+            True,
+            True,
+            False,
+        )
+        self._register_service(
+            DOMAIN,
+            SERVICE_FDM5KW_STOP_WATERING,
+            self._handle_fdm5kw_stop_watering,
+            SERVICE_FDM5KW_STOP_WATERING_SCHEMA,
+            True,
+            True,
+            False,
+        )
+        self._register_service(
+            DOMAIN,
+            SERVICE_FDM5KW_CLEAR_QUOTA_LOCKOUT,
+            self._handle_fdm5kw_clear_quota_lockout,
+            SERVICE_FDM5KW_CLEAR_QUOTA_LOCKOUT_SCHEMA,
+            True,
+            True,
+            False,
+        )
+        self._register_service(
+            DOMAIN,
+            SERVICE_FDM5KW_RESYNC_TIMERS,
+            self._handle_fdm5kw_resync_timers,
+            SERVICE_FDM5KW_RESYNC_TIMERS_SCHEMA,
+            True,
+            True,
+            False,
+            # Returns per-valve reconcile counts so the dashboard button can
+            # report "cleared N / all clean" instead of a blind fire.
+            supports_response=SupportsResponse.OPTIONAL,
+        )
 
     def _register_service(
         self,
@@ -142,8 +251,11 @@ class ServiceManager:
         requires_auth: bool = True,
         allow_from_api: bool = True,
         use_cache: bool = True,
+        supports_response: SupportsResponse = SupportsResponse.NONE,
     ):
-        self.hass.services.async_register(domain, name, callback, schema=schema)
+        self.hass.services.async_register(
+            domain, name, callback, schema=schema, supports_response=supports_response
+        )
         if allow_from_api:
             self.hass.http.register_view(
                 XTGeneralView(name, callback, requires_auth, use_cache)
@@ -309,3 +421,50 @@ class ServiceManager:
                         )
                         return response
                 return None
+
+    async def _handle_fdm5kw_set_timer(
+        self, event: XTEventData
+    ) -> dict[str, Any] | None:
+        from ....entity_parser.fdm5kw.timer_service import set_timer
+
+        ok = await set_timer(self.hass, event.data)
+        return {"success": ok}
+
+    async def _handle_fdm5kw_delete_timer(
+        self, event: XTEventData
+    ) -> dict[str, Any] | None:
+        from ....entity_parser.fdm5kw.timer_service import delete_timer
+
+        ok = await delete_timer(self.hass, event.data)
+        return {"success": ok}
+
+    async def _handle_fdm5kw_start_watering(
+        self, event: XTEventData
+    ) -> dict[str, Any] | None:
+        from ....entity_parser.fdm5kw.control_service import start_watering
+
+        ok = await start_watering(self.hass, event.data)
+        return {"success": ok}
+
+    async def _handle_fdm5kw_stop_watering(
+        self, event: XTEventData
+    ) -> dict[str, Any] | None:
+        from ....entity_parser.fdm5kw.control_service import stop_watering
+
+        ok = await stop_watering(self.hass, event.data)
+        return {"success": ok}
+
+    async def _handle_fdm5kw_clear_quota_lockout(
+        self, event: XTEventData
+    ) -> dict[str, Any] | None:
+        from ....entity_parser.fdm5kw.timer_service import clear_quota_lockout
+
+        clear_quota_lockout()
+        return {"success": True}
+
+    async def _handle_fdm5kw_resync_timers(
+        self, event: XTEventData
+    ) -> dict[str, Any] | None:
+        from ....entity_parser.fdm5kw.timer_service import resync_from_cloud
+
+        return await resync_from_cloud(self.hass, event.data)

--- a/custom_components/xtend_tuya/sensor.py
+++ b/custom_components/xtend_tuya/sensor.py
@@ -110,6 +110,23 @@ if TYPE_CHECKING:
 
 COMPOUND_KEY: list[str | tuple[str, ...]] = ["key", "dpcode"]
 
+# Liters ceiling for a single cur_cap reading. The QT-08W impeller tops out
+# at 25 L/min, so even a long (6 h) cycle can't exceed 25 * 360 = 9000 L. The
+# cur_cap DP intermittently reports a garbage spike (e.g. 177610 L) that is
+# physically impossible; drop any reading above this so the watering-volume
+# sensor and its history graph don't show the spike.
+SANE_CUR_CAP_MAX = 9000
+
+
+def filter_cur_cap_spike(value: object) -> int | None:
+    """Return cur_cap as int, or None if it's an impossible glitch spike."""
+    try:
+        v = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+    return int(v) if v <= SANE_CUR_CAP_MAX else None
+
+
 class XTB64ToDateTimeStringWrapper(TuyaDPCodeStringWrapper[datetime]):
     def read_device_status(self, device: TuyaCustomerDevice) -> datetime | None:
         """Read device status and convert to a Home Assistant value."""
@@ -225,9 +242,21 @@ def xt_get_default_definition(
                 function_code=dpcode,
                 scale_threshold=description.recalculate_scale_for_percentage_threshold,
             )
-    return get_default_definition(
-        device=device, dpcode=dpcode, wrapper_class=description.wrapper_class
-    )
+    try:
+        return get_default_definition(
+            device=device, dpcode=dpcode, wrapper_class=description.wrapper_class
+        )
+    except (KeyError, TypeError, ValueError) as err:
+        # Upstream tuya_device_handlers raises on DPs with incomplete type_data
+        # (e.g. integer DP missing "min"). Skip the DP instead of aborting the
+        # whole post-setup callback, which would fail the entire account entry.
+        LOGGER.warning(
+            "Skipping generic sensor for device=%s dpcode=%s — incomplete DP definition (%s)",
+            getattr(device, "id", "?"),
+            dpcode,
+            err,
+        )
+        return None
 
 
 @dataclass(frozen=True)
@@ -1889,6 +1918,21 @@ SENSORS: dict[str, tuple[XTSensorEntityDescription, ...]] = {
             device_class=SensorDeviceClass.WATER,
             native_unit_of_measurement="L",
             suggested_display_precision=0,
+            # Drop cur_cap glitch spikes (see filter_cur_cap_spike) so the
+            # detail-card volume + its graph never show an impossible value.
+            native_value=filter_cur_cap_spike,
+            # cur_cap resets to 0 each cycle; TOTAL_INCREASING lets HA
+            # long-term stats treat each reset as a new accumulator window,
+            # giving an all-time water figure. FDM5KW has no water_total DP.
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            # The fdm5kw module also registers a Fdm5kwFlowRateDescription on
+            # the same cur_cap DP. Whichever descriptor reaches the platform
+            # setup first registers the handler; without this flag the other
+            # one fails XTEntity.supports_description's "dpcode already
+            # handled" gate, never spawns, and HA marks the entity as a
+            # state-restored orphan (state=unavailable, restored=True). Set
+            # on both descriptors so iteration order doesn't matter.
+            ignore_other_dp_code_handler=True,
         ),
         XTSensorEntityDescription(
             key=XTDPCode.CYC_NUM,
@@ -2085,6 +2129,19 @@ async def async_setup_entry(
     this_platform = Platform.SENSOR
     if entry.runtime_data.multi_manager is None or hass_data.manager is None:
         return
+
+    # Hub-level controllable-device quota sensor (OpenAPI hubs only).
+    _mm = entry.runtime_data.multi_manager
+    if getattr(_mm, "controllable_quota", None) is not None:
+        from .multi_manager.shared.quota import XTControllableQuotaSensor
+
+        async_add_entities(
+            [
+                XTControllableQuotaSensor(
+                    _mm.controllable_quota, entry.title or _mm.controllable_quota.hub_id
+                )
+            ]
+        )
 
     supported_descriptors, externally_managed_descriptors = cast(
         tuple[

--- a/custom_components/xtend_tuya/services.yaml
+++ b/custom_components/xtend_tuya/services.yaml
@@ -63,3 +63,74 @@ webrtc_debug:
       required: false
       example: "tuya_iot"
       default: "tuya_iot"
+
+fdm5kw_set_timer:
+  fields:
+    device_id:
+      required: true
+      example: "bfbc9ae1e1ad6d3135vxmj"
+    slot:
+      required: true
+      example: 0
+    hour:
+      required: true
+      example: 7
+    minute:
+      required: true
+      example: 0
+    mode:
+      required: true
+      example: "duration"
+    value:
+      required: true
+      example: 1200
+    days:
+      required: false
+      example: "[Mon, Wed, Fri]"
+    enabled:
+      required: false
+      default: true
+
+fdm5kw_delete_timer:
+  fields:
+    device_id:
+      required: true
+      example: "bfbc9ae1e1ad6d3135vxmj"
+    slot:
+      required: true
+      example: 0
+    hour:
+      required: false
+      example: 7
+    minute:
+      required: false
+      example: 0
+    days:
+      required: false
+      example: "[Mon, Wed, Fri]"
+
+fdm5kw_start_watering:
+  fields:
+    device_id:
+      required: true
+      example: "bfbc9ae1e1ad6d3135vxmj"
+    mode:
+      required: true
+      example: "duration"
+    value:
+      required: true
+      example: 60
+
+fdm5kw_stop_watering:
+  fields:
+    device_id:
+      required: true
+      example: "bfbc9ae1e1ad6d3135vxmj"
+
+fdm5kw_clear_quota_lockout:
+
+fdm5kw_resync_timers:
+  fields:
+    device_id:
+      required: true
+      example: "bfbc9ae1e1ad6d3135vxmj"

--- a/custom_components/xtend_tuya/strings.json
+++ b/custom_components/xtend_tuya/strings.json
@@ -288,6 +288,112 @@
         "reload": {
             "name": "[%key:common::action::reload%]",
             "description": "Reloads the automation configuration."
+        },
+        "fdm5kw_set_timer": {
+            "name": "Set fdm5kw irrigation timer",
+            "description": "Write a scheduled irrigation timer into one slot of a QT-08W valve.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                },
+                "slot": {
+                    "name": "Slot",
+                    "description": "Timer slot index to write (0-based)."
+                },
+                "hour": {
+                    "name": "Hour",
+                    "description": "Start hour, 0-23, in the Home Assistant time zone."
+                },
+                "minute": {
+                    "name": "Minute",
+                    "description": "Start minute, 0-59."
+                },
+                "mode": {
+                    "name": "Mode",
+                    "description": "Stop condition: 'duration' for seconds, or 'volume' for liters."
+                },
+                "value": {
+                    "name": "Value",
+                    "description": "Duration in seconds, or volume in liters, depending on mode."
+                },
+                "days": {
+                    "name": "Days",
+                    "description": "Weekdays the timer repeats on, e.g. [Mon, Wed, Fri]. Omit for a daily timer."
+                },
+                "enabled": {
+                    "name": "Enabled",
+                    "description": "Whether the timer is active. Defaults to true."
+                }
+            }
+        },
+        "fdm5kw_delete_timer": {
+            "name": "Delete fdm5kw irrigation timer",
+            "description": "Remove a scheduled irrigation timer from a QT-08W valve.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                },
+                "slot": {
+                    "name": "Slot",
+                    "description": "Timer slot index to clear (0-based)."
+                },
+                "hour": {
+                    "name": "Hour",
+                    "description": "Optional start hour, used to confirm the slot matches before deleting."
+                },
+                "minute": {
+                    "name": "Minute",
+                    "description": "Optional start minute, used to confirm the slot matches before deleting."
+                },
+                "days": {
+                    "name": "Days",
+                    "description": "Optional weekday list, used to confirm the slot matches before deleting."
+                }
+            }
+        },
+        "fdm5kw_start_watering": {
+            "name": "Start fdm5kw watering",
+            "description": "Open a QT-08W valve for a single run, stopping after a duration or a volume.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                },
+                "mode": {
+                    "name": "Mode",
+                    "description": "Stop condition: 'duration' for seconds, or 'volume' for liters."
+                },
+                "value": {
+                    "name": "Value",
+                    "description": "Duration in seconds, or volume in liters, depending on mode."
+                }
+            }
+        },
+        "fdm5kw_stop_watering": {
+            "name": "Stop fdm5kw watering",
+            "description": "Close a QT-08W valve and end the current run.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                }
+            }
+        },
+        "fdm5kw_clear_quota_lockout": {
+            "name": "Clear fdm5kw cloud-timer quota lockout",
+            "description": "Reset the circuit breaker that suppresses Tuya cloud-timer writes after a 60001001 'controllable device pool quota insufficient' error. Call this after upgrading the IoT Core plan or removing devices so the next timer change retries the cloud write. Writes that go straight to the device were never affected by the lockout."
+        },
+        "fdm5kw_resync_timers": {
+            "name": "Resync fdm5kw timers from cloud",
+            "description": "Reconcile the Home Assistant timer registry for one valve against the Tuya cloud and drop slots the cloud no longer knows about. Disabled leftovers are dropped without a device write; an enabled orphan slot, which would otherwise water unattended, is cleared with a device write that costs one controllable-device unit. Returns the reconcile counts.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                }
+            }
         }
     },
     "entity": {

--- a/custom_components/xtend_tuya/translations/en.json
+++ b/custom_components/xtend_tuya/translations/en.json
@@ -288,6 +288,112 @@
         "reload": {
             "name": "[%key:common::action::reload%]",
             "description": "Reloads the automation configuration."
+        },
+        "fdm5kw_set_timer": {
+            "name": "Set fdm5kw irrigation timer",
+            "description": "Write a scheduled irrigation timer into one slot of a QT-08W valve.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                },
+                "slot": {
+                    "name": "Slot",
+                    "description": "Timer slot index to write (0-based)."
+                },
+                "hour": {
+                    "name": "Hour",
+                    "description": "Start hour, 0-23, in the Home Assistant time zone."
+                },
+                "minute": {
+                    "name": "Minute",
+                    "description": "Start minute, 0-59."
+                },
+                "mode": {
+                    "name": "Mode",
+                    "description": "Stop condition: 'duration' for seconds, or 'volume' for liters."
+                },
+                "value": {
+                    "name": "Value",
+                    "description": "Duration in seconds, or volume in liters, depending on mode."
+                },
+                "days": {
+                    "name": "Days",
+                    "description": "Weekdays the timer repeats on, e.g. [Mon, Wed, Fri]. Omit for a daily timer."
+                },
+                "enabled": {
+                    "name": "Enabled",
+                    "description": "Whether the timer is active. Defaults to true."
+                }
+            }
+        },
+        "fdm5kw_delete_timer": {
+            "name": "Delete fdm5kw irrigation timer",
+            "description": "Remove a scheduled irrigation timer from a QT-08W valve.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                },
+                "slot": {
+                    "name": "Slot",
+                    "description": "Timer slot index to clear (0-based)."
+                },
+                "hour": {
+                    "name": "Hour",
+                    "description": "Optional start hour, used to confirm the slot matches before deleting."
+                },
+                "minute": {
+                    "name": "Minute",
+                    "description": "Optional start minute, used to confirm the slot matches before deleting."
+                },
+                "days": {
+                    "name": "Days",
+                    "description": "Optional weekday list, used to confirm the slot matches before deleting."
+                }
+            }
+        },
+        "fdm5kw_start_watering": {
+            "name": "Start fdm5kw watering",
+            "description": "Open a QT-08W valve for a single run, stopping after a duration or a volume.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                },
+                "mode": {
+                    "name": "Mode",
+                    "description": "Stop condition: 'duration' for seconds, or 'volume' for liters."
+                },
+                "value": {
+                    "name": "Value",
+                    "description": "Duration in seconds, or volume in liters, depending on mode."
+                }
+            }
+        },
+        "fdm5kw_stop_watering": {
+            "name": "Stop fdm5kw watering",
+            "description": "Close a QT-08W valve and end the current run.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                }
+            }
+        },
+        "fdm5kw_clear_quota_lockout": {
+            "name": "Clear fdm5kw cloud-timer quota lockout",
+            "description": "Reset the circuit breaker that suppresses Tuya cloud-timer writes after a 60001001 'controllable device pool quota insufficient' error. Call this after upgrading the IoT Core plan or removing devices so the next timer change retries the cloud write. Writes that go straight to the device were never affected by the lockout."
+        },
+        "fdm5kw_resync_timers": {
+            "name": "Resync fdm5kw timers from cloud",
+            "description": "Reconcile the Home Assistant timer registry for one valve against the Tuya cloud and drop slots the cloud no longer knows about. Disabled leftovers are dropped without a device write; an enabled orphan slot, which would otherwise water unattended, is cleared with a device write that costs one controllable-device unit. Returns the reconcile counts.",
+            "fields": {
+                "device_id": {
+                    "name": "Device ID",
+                    "description": "Tuya device ID of the valve."
+                }
+            }
         }
     },
     "entity": {

--- a/tests/test_t3_decode.py
+++ b/tests/test_t3_decode.py
@@ -1,0 +1,118 @@
+"""Self-check for the QT-08W-T3 DP decoders (sensor.py).
+
+Standalone (no HA import) — mirrors the byte math in the DPCodeSat0*/
+DPCodeFlowStaVolume/DPCodeCounterCustom wrappers and asserts it against the
+REAL payloads captured live 2026-07-15 (see irrigation-t3-dp-decode.md). Fails
+if anyone shifts a byte offset. Run: `python test_t3_decode.py`.
+"""
+import base64
+
+
+def battery(b):          # DPCodeSat0BatteryWrapper
+    return b[3] & 0x7F if len(b) >= 4 else None
+
+
+def next_run(b):         # DPCodeSat0NextRunWrapper
+    if len(b) < 12:
+        return None
+    y, mo, d, h, mi = b[7], b[8], b[9], b[10], b[11]
+    if y == 0xFF or mo == 0 or mo > 12 or d == 0 or d > 31:
+        return None
+    return f"20{y:02d}-{mo:02d}-{d:02d} {h:02d}:{mi:02d}:00"
+
+
+# Same ceiling the wrapper uses; a reading above it is a DP glitch, not water.
+SANE_CUR_CAP_MAX = 9000
+
+
+def flow_volume(b):      # DPCodeFlowStaVolumeWrapper
+    if len(b) < 5:
+        return None
+    vol = int.from_bytes(b[1:5], "big")
+    if vol > SANE_CUR_CAP_MAX:
+        return None      # glitch guard, same ceiling as cur_cap
+    return vol
+
+
+def counter_volume(csv):  # DPCodeCounterCustomVolumeWrapper
+    p = csv.split(",")
+    if len(p) < 5 or int(p[2]) == 65534:
+        return None
+    return int(p[3])
+
+
+def time_task(b):  # DPCodeT3TimeTaskWrapper.update_data
+    if len(b) < 12:
+        return None
+    mode, value = b[3], int.from_bytes(b[4:8], "big")
+    hour, minute, days_mask, enabled = b[8], b[9], b[10], b[11]
+    if not value and not hour and not minute and not days_mask and not enabled:
+        return None  # empty slot
+    return {"slot": b[1], "mode": "duration" if mode == 0 else "volume",
+            "value": value, "hour": hour, "minute": minute,
+            "days_mask": days_mask, "enabled": bool(enabled)}
+
+
+def build_t3(index, mode, value, hour, minute, days_mask, enabled):
+    # mirror of build_time_task_payload_t3 in timer_service.py
+    return bytes([0, index, index, mode,
+                  (value >> 24) & 0xFF, (value >> 16) & 0xFF,
+                  (value >> 8) & 0xFF, value & 0xFF,
+                  hour, minute, days_mask & 0x7F, 1 if enabled else 0])
+
+
+def demo():
+    d = base64.b64decode
+    # sat_0 (701): battery 100%, next 2026-07-15 16:00
+    sat = d("AAEAZAABABoHDxAAAA==")
+    assert battery(sat) == 100, battery(sat)
+    assert next_run(sat) == "2026-07-15 16:00:00", next_run(sat)
+    # sat_0 charge-flag frame (byte3=0xE4) still = 100%
+    assert battery(d("AAEA5AABABoHDg4tAA==")) == 100
+    # sat_0 idle frame (ff schedule) -> no next run
+    assert next_run(d("AAEAZAEBAP///////w==")) is None
+    # flow_sta_0 (701): final frame volume 113 L
+    assert flow_volume(d("AAAAAHEAAAJY//////////8A")) == 113
+    # flow_sta_0 mid-run frame: 90 L
+    assert flow_volume(d("AAAAAFoAAAAADhAAAA4QCgAA")) == 90
+    # Glitch guard: the DP intermittently reports a physically impossible
+    # total (the impeller tops out at 25 L/min, so 9000 L is already a 6 h
+    # ceiling). Anything above it must be dropped, not shown as a run.
+    assert flow_volume(bytes([0x00, 0x00, 0x02, 0xB5, 0xCA])) is None   # 177610 L
+    assert flow_volume(bytes([0x00, 0x00, 0x00, 0x23, 0x28])) == 9000   # exactly at the ceiling, kept
+    # counter_custom: last run 113 L; aborted (65534) -> None
+    assert counter_volume("0,1,600,113,20260714161000") == 113
+    assert counter_volume("0,1,65534,9,20260714155958") is None
+    # time_task_0 — Timer A (idx0, 3min/180s, 03:03, Mon, duration)
+    a = time_task(d("AAAAAAAAALQDAwEB"))
+    assert a == {"slot": 0, "mode": "duration", "value": 180, "hour": 3,
+                 "minute": 3, "days_mask": 0x01, "enabled": True}, a
+    # Timer B (idx1, 6min/360s, 06:06, Tue, duration)
+    b = time_task(d("AAEBAAAAAWgGBgIB"))
+    assert b == {"slot": 1, "mode": "duration", "value": 360, "hour": 6,
+                 "minute": 6, "days_mask": 0x02, "enabled": True}, b
+    # Volume timer (idx1, 33 L, 05:07, all days)
+    v = time_task(d("AAEBAQAAACEFB38B"))
+    assert v["mode"] == "volume" and v["value"] == 33 and v["slot"] == 1, v
+    # All-zero payload = empty slot
+    assert time_task(bytes(12)) is None
+    # builder round-trips through the decoder (write -> read parity)
+    assert time_task(build_t3(1, 0, 360, 6, 6, 0x02, True)) == {
+        "slot": 1, "mode": "duration", "value": 360, "hour": 6,
+        "minute": 6, "days_mask": 0x02, "enabled": True}
+    assert time_task(build_t3(2, 1, 33, 5, 7, 0x7F, True))["mode"] == "volume"
+    # delete payload (all-zero at index) decodes as empty slot
+    assert time_task(bytes([0, 3] + [0] * 10)) is None
+    # cyc_control_0 single-run builder matches the live 706 capture
+    assert cyc_control(60, 1) == bytes.fromhex("00000000003c01000001".zfill(20))
+    assert cyc_control(60, 0)[9] == 0 and cyc_control(60, 1)[9] == 1
+    print("T3 decode self-check OK")
+
+
+def cyc_control(value, flag):  # mirror of build_cyc_control_payload
+    return bytes([0, 0, (value >> 24) & 0xFF, (value >> 16) & 0xFF,
+                  (value >> 8) & 0xFF, value & 0xFF, 1, 0, 0, flag & 0xFF])
+
+
+if __name__ == "__main__":
+    demo()


### PR DESCRIPTION
Follow-up to #1020, second part of the series discussed there.

## What this adds

Full support for the **fdm5kw irrigation valve** (sfkzq category, QOTO QT-08W and the newer QT-08W-T3), driven by a dedicated entity parser under `entity_parser/fdm5kw/`:

- **Timer registry** decoded from the `time_task` raw DP (slot model incl. the byte[1]=enabled flag), exposed as sensors with full schedule attributes; T3's indexed 4-program model (`sat_0`-packed battery, DP-instruction mode) handled by the same parser (`tests/test_t3_decode.py`).
- **Watering telemetry**: cur_cap-based watering volume / flow rate, battery (vbat), start/close timestamps, one_control mode+value.
- **6 services** (single watering, timer create/update/delete/enable, resync) with `services.yaml` + translations.
- **OpenAPI quota tracker** (`multi_manager/shared/quota.py`): surfaces the cloud project's controllable-device quota as a sensor so trial-tier users can see why control calls start failing.
- **Location service**: walks the SmartLife homes of each account and maps device→home/room, used to enrich the valve sensors' attributes.

## Scope

Backend only — no frontend/cards in this PR (that is the third part, opt-in). No changes to existing platforms beyond descriptor registration hooks already present.

## Testing

- `tests/test_t3_decode.py` runs standalone (`python tests/test_t3_decode.py`).
- Running in production since June against ~100 physical valves across two accounts (both QT-08W and QT-08W-T3 hardware).