### PR TITLE
Fix: reload revokes Tuya session; select.py generic type mismatch (Python 3.14)

### DIFF
--- a/custom_components/xtend_tuya/__init__.py
+++ b/custom_components/xtend_tuya/__init__.py
@@ -369,9 +369,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: XTConfigEntry) -> bool:
             if tuya.manager.mq is not None:
                 tuya.manager.mq.stop()
             tuya.manager.remove_device_listeners()
-            await XTEventLoopProtector.execute_out_of_event_loop_and_return(
-                tuya.manager.unload
-            )
+            # Intentionally NOT calling tuya.manager.unload() here.
+            # Manager.unload() -> UserRepository.unload() POSTs to Tuya's
+            # "/v1.0/m/token/terminal/expire" endpoint, which revokes this
+            # terminal's session server-side. That is correct when the
+            # config entry is actually being removed (see
+            # async_remove_entry below, which still calls it), but
+            # async_unload_entry also fires on every plain reload (options
+            # change, HA restart, manual "Reload"). Calling the same
+            # server-side logout there invalidates the stored
+            # refresh_token, and a handful of reloads in a row leave the
+            # account requiring a brand new QR login to recover
+            # ("Authentication failed. Please re-authenticate.").
     return unload_ok
 
 

--- a/custom_components/xtend_tuya/select.py
+++ b/custom_components/xtend_tuya/select.py
@@ -94,7 +94,7 @@ class XTEnumWithFixedValuesTypeInformation(TuyaEnumTypeInformation):
                         return type_information
         return None
 
-class XTDPCodeEnumWrapperWithFixedOptions[T = str](TuyaDPCodeTypeInformationWrapper[XTEnumWithFixedValuesTypeInformation, str, T]):
+class XTDPCodeEnumWrapperWithFixedOptions[T = str](TuyaDPCodeTypeInformationWrapper[XTEnumWithFixedValuesTypeInformation, T]):
     _DPTYPE = XTEnumWithFixedValuesTypeInformation
     options: list[str]
     


### PR DESCRIPTION
## Two independent bugs, found while diagnosing why a working account needed a fresh QR login after a handful of plain reloads (HA 2026.5.3, Python 3.14.2)

### 1. `async_unload_entry` revokes the Tuya session on every reload, not just on removal

`async_unload_entry` unconditionally calls `tuya.manager.unload()`, which goes:

```
Manager.unload() -> UserRepository.unload() -> POST /v1.0/m/token/terminal/expire
```

That explicitly revokes the terminal's session server-side. It's the correct call inside `async_remove_entry` (which already calls it, and its docstring says *"This will revoke the credentials from Tuya"* — clearly intentional there). But `async_unload_entry` also runs on every plain reload: options change, HA restart, the manual "Reload" button. A handful of reloads in a row leave the stored `refresh_token` permanently invalid, and the integration starts failing with:

```
Authentication failed. Please re-authenticate.
```

with no config or code change involved — just reloading. Recovery requires deleting the integration and doing a fresh QR login.

**Fix:** only stop the MQTT connection and local listeners in `async_unload_entry`. Leave the actual session-revoking call exclusively in `async_remove_entry`, where it belongs.

### 2. `select.py` generic type params don't match the real base class (Python 3.14)

```python
class XTDPCodeEnumWrapperWithFixedOptions[T = str](TuyaDPCodeTypeInformationWrapper[XTEnumWithFixedValuesTypeInformation, str, T]):
```

passes **3** type parameters, but the real base class only accepts **2**:

```python
class DPCodeTypeInformationWrapper[TypeInformationT: TypeInformation, T](DPCodeWrapper[T]):
```

Under Python 3.14's stricter PEP 695 generic-parameter checking this raises at import time, crashing the entire integration setup:

```
TypeError: Too many arguments for <class 'tuya_device_handlers.device_wrapper.common.DPCodeTypeInformationWrapper'>; actual 3, expected 2
```

Reproduced on both `v4.5.1` and `v4.5.2-beta.6` against a live install. **Fix:** drop the redundant `str` argument.

## Testing

Both fixes verified live against a real Home Assistant 2026.5.3 / Python 3.14.2 instance with an active `tuya_sharing` account (multiple Tuya devices across categories `tdq`, `kg`, `cz`, `hwktwkq`): integration loads cleanly, existing entities unaffected, and a dozen back-to-back reloads no longer trigger re-authentication.

Separately opening an issue with a proposed enhancement for categories whose ambient sensor data only reaches Tuya's newer shadow/properties model (not covered by this PR, since it's a feature addition rather than a bugfix and the right design is more opinionated).