### PR TITLE
Feature: shadow/properties fallback for categories with empty DP status (tdq T&H sensor, hwktwkq AC hub)

### DIFF
--- a/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/xt_tuya_sharing_device_repository.py
+++ b/custom_components/xtend_tuya/multi_manager/managers/tuya_sharing/xt_tuya_sharing_device_repository.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from types import SimpleNamespace
 from typing import Any
 import json
 from tuya_sharing.device import (
@@ -22,6 +23,74 @@ from ...shared.threading import (
 from ....const import (
     LOGGER,  # noqa: F401
 )
+
+# Known DP layouts for device categories whose Tuya-side specifications/status
+# are empty for some products (the cloud "shadow properties" data model exposes
+# these dpcodes, but the legacy DP status/specification APIs never populated
+# them for these products). Values mirror the well-documented layout used by
+# the community "Tuya Local" workaround for the same hardware.
+# See: https://github.com/home-assistant/core/issues/150902 (and duplicates
+# #142137, #130949, #135280) plus
+# https://community.home-assistant.io/t/tuya-t-h-sensor-unsupported/850996
+_KNOWN_CATEGORY_DP_SPECS: dict[str, dict[str, dict[str, Any]]] = {
+    # "tdq" here is the temperature & humidity sensor product line (product_id
+    # x3o8epevyeo3z3oa "T & H Sensor" and likely siblings), not to be confused
+    # with the unrelated "tdq" reuse of the "kg" sensor descriptors elsewhere.
+    "tdq": {
+        "temp_current": {
+            "dp_id": 27,
+            "type": "Integer",
+            "values": json.dumps(
+                {"unit": "℃", "min": -400, "max": 1000, "scale": 1, "step": 1}
+            ),
+        },
+        "humidity_value": {
+            "dp_id": 46,
+            "type": "Integer",
+            "values": json.dumps(
+                {"unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1}
+            ),
+        },
+        "battery_state": {
+            "dp_id": 101,
+            "type": "Enum",
+            "values": json.dumps({"range": ["low", "middle", "high"]}),
+        },
+    },
+    # "hwktwkq" is Tuya's "Smart AC Controller" hub category (product_id
+    # 6qvdtaoelxa4k5c5 seen here, likely shared by siblings). The hub has a
+    # built-in ambient temperature/humidity sensor feeding its own IR-based
+    # AC control loop, but -- same root cause as "tdq" above -- the reading
+    # only ever reaches Tuya's newer shadow/properties model, never the
+    # legacy DP status cache these dpcodes/scales were read directly off a
+    # live device via shadow/properties on 2026-09-07.
+    "hwktwkq": {
+        "temp_current": {
+            "dp_id": 2,
+            "type": "Integer",
+            "values": json.dumps(
+                {"unit": "℃", "min": -400, "max": 1000, "scale": 1, "step": 1}
+            ),
+        },
+        # Key is "humidity_value" (not the device's real dpcode
+        # "humidity_current") so this lands on the same, already-recognized
+        # generic sensor code as the "tdq" category above -- HA's generic
+        # dpcode-to-sensor recognition only fires for a known allowlist of
+        # code names, and "humidity_current" isn't on it (silently produces
+        # no entity at all, not even a disabled one, unlike "temp_current"
+        # which IS recognized). "shadow_code" records the real dpcode name
+        # so the value can still be pulled from the shadow/properties
+        # response correctly.
+        "humidity_value": {
+            "dp_id": 12,
+            "type": "Integer",
+            "shadow_code": "humidity_current",
+            "values": json.dumps(
+                {"unit": "%", "min": 0, "max": 100, "scale": 0, "step": 1}
+            ),
+        },
+    },
+}
 
 
 class XTSharingDeviceRepository(DeviceRepository):
@@ -74,10 +143,37 @@ class XTSharingDeviceRepository(DeviceRepository):
                         )
                         # device.status[key] = False
 
+    def _fix_known_category_device_specification(self, device: CustomerDevice):
+        """Backfill status_range/function for categories/products whose Tuya
+        specification response never included them, using a hardcoded known
+        DP layout. Only fills in codes that are genuinely missing so this
+        never overrides real data the cloud did provide."""
+        known_specs = _KNOWN_CATEGORY_DP_SPECS.get(device.category)
+        if not known_specs:
+            return
+        for code, spec in known_specs.items():
+            if code not in device.status_range:
+                device.status_range[code] = SimpleNamespace(
+                    code=code,
+                    type=spec["type"],
+                    values=spec["values"],
+                    dp_id=spec["dp_id"],
+                )
+            if code not in device.function:
+                device.function[code] = SimpleNamespace(
+                    code=code,
+                    type=spec["type"],
+                    values=spec["values"],
+                    dp_id=spec["dp_id"],
+                    desc="",
+                    name=code,
+                )
+
     def update_device_specification(self, device: CustomerDevice):
         super().update_device_specification(device)
 
         self._fix_infrared_device_specification(device)
+        self._fix_known_category_device_specification(device)
 
         # Now convert the status_range and function to XT format
         for code in device.status_range:
@@ -100,6 +196,30 @@ class XTSharingDeviceRepository(DeviceRepository):
             return []
         return self._query_devices(response)
 
+    def _get_shadow_properties(self, device_id: str) -> dict[str, Any]:
+        """Fetch the cloud "Things Data Model" shadow properties for a device.
+
+        Some products (e.g. category "tdq" / product_id x3o8epevyeo3z3oa "T & H
+        Sensor") never populate the legacy DP status cache used by
+        query_devices_by_home/devices/detail, even though the device reports
+        fine and the value is visible in the Smart Life app. That data lives
+        in the newer shadow/properties model instead, reachable with the same
+        sharing-session credentials (no separate OpenAPI project needed).
+        """
+        try:
+            response = self.api.get(f"/v1.0/m/life/ha/{device_id}/shadow/properties")
+        except Exception as e:
+            LOGGER.debug(f"_get_shadow_properties failed for {device_id}: {e}")
+            return {}
+        if not response or not response.get("success"):
+            return {}
+        properties = response.get("result", {}).get("properties", [])
+        return {
+            p["code"]: p["value"]
+            for p in properties
+            if "code" in p and "value" in p
+        }
+
     def _query_devices(self, response) -> list[CustomerDevice]:
         _devices = []
 
@@ -111,6 +231,25 @@ class XTSharingDeviceRepository(DeviceRepository):
                     code = item_status["code"]  # type: ignore
                     value = item_status["value"]  # type: ignore
                     status[code] = value
+            known_specs = _KNOWN_CATEGORY_DP_SPECS.get(device.category)
+            if known_specs and any(
+                code not in status
+                and spec.get("shadow_code", code) not in status
+                for code, spec in known_specs.items()
+            ):
+                shadow_status = self._get_shadow_properties(device.id)
+                # Merge everything reported, not just the codes we know
+                # about -- costs nothing and keeps data (setpoint, mode,
+                # fan speed, etc.) available for other code to use later.
+                for code, value in shadow_status.items():
+                    status.setdefault(code, value)
+                # For codes whose real Tuya dpcode isn't on HA's generic
+                # sensor allowlist, also expose the value under our
+                # "canonical" (recognized) code name.
+                for code, spec in known_specs.items():
+                    shadow_code = spec.get("shadow_code", code)
+                    if code not in status and shadow_code in status:
+                        status[code] = status[shadow_code]
             device.status = status
             self.update_device_specification(device)
             self.update_device_strategy_info(device)
@@ -127,10 +266,10 @@ class XTSharingDeviceRepository(DeviceRepository):
         device_id = device.id
         response = self.api.get(f"/v1.0/m/life/devices/{device_id}/status")
         support_local = True
+        dp_id_map = {}
         if response.get("success"):
             result = response.get("result", {})
             pid = result["productKey"]
-            dp_id_map = {}
             for dp_status_relation in result["dpStatusRelationDTOS"]:
                 if not dp_status_relation["supportLocal"]:
                     support_local = False
@@ -149,9 +288,26 @@ class XTSharingDeviceRepository(DeviceRepository):
                         },  # CHANGED
                         "status_code_alias": [],  # CHANGED
                     }
-            device.support_local = support_local
-            # if support_local:                      #CHANGED
-            device.local_strategy = dp_id_map  # CHANGED
+        known_specs = _KNOWN_CATEGORY_DP_SPECS.get(device.category)
+        if known_specs:
+            for code, spec in known_specs.items():
+                if spec["dp_id"] in dp_id_map:
+                    continue
+                dp_id_map[spec["dp_id"]] = {
+                    "value_convert": "default",
+                    "status_code": code,
+                    "config_item": {
+                        "statusFormat": json.dumps({code: "$"}),
+                        "valueDesc": spec["values"],
+                        "valueType": spec["type"],
+                        "enumMappingMap": {},
+                        "pid": device.product_id,
+                    },
+                    "status_code_alias": [],
+                }
+        device.support_local = support_local
+        # if support_local:                      #CHANGED
+        device.local_strategy = dp_id_map  # CHANGED
 
     def update_device_strategy_info(self, device: CustomerDevice):
         self._update_device_strategy_info_mod(device)


### PR DESCRIPTION
Follow-up to #1049 — this one's a feature/design proposal rather than an obvious bugfix, opening it separately so #1049 isn't held up by discussion here.

## The problem

Some Tuya products never populate the legacy DP status cache used by `query_devices_by_home` / `devices/detail` / `devices/{id}/status` — they show up in Home Assistant with empty `status`, no usable entities beyond the generic `xt_device_event_notify` event — even though the value is visible live in the Smart Life app and the device is reporting fine.

That data lives in Tuya's newer "Things Data Model" instead: `GET /v1.0/m/life/ha/{device_id}/shadow/properties`. It works with the **existing** `tuya_sharing` session credentials already stored by this integration — no separate OpenAPI project / access_id / access_secret needed.

## The fix

Adds a merge step in `_query_devices_thread`: for device categories listed in a new `_KNOWN_CATEGORY_DP_SPECS` map, if any expected codes are missing from `status`, fetch `shadow/properties` and merge in everything it returns (not just the known codes — costs nothing extra and keeps setpoint/mode/fan-speed etc. around for other code to use later).

Schema info (scale/unit/min/max) is hardcoded per category, mirroring the pattern this file already uses for `infrared_*` categories in `_fix_infrared_device_specification` — Tuya's own specification endpoints are just as empty for these products as the status endpoint is, so there's nothing to read the schema from.

## Categories added (both verified against live devices)

- **`tdq`** (product_id `x3o8epevyeo3z3oa` "T & H Sensor", likely siblings): `temp_current`, `humidity_value`, `battery_state`. This exact product has several open "unsupported" reports: home-assistant/core#150902, #142137, #130949, #135280, and the [community thread](https://community.home-assistant.io/t/tuya-t-h-sensor-unsupported/850996).
- **`hwktwkq`** (Tuya's "Smart AC Controller" hub category, product_id `6qvdtaoelxa4k5c5` seen here): `temp_current`, `humidity_current`. The hub has a built-in ambient sensor feeding its own IR-based AC control loop, but has the same gap.

One quirk worth flagging: the humidity dpcode HA's generic sensor-creation path recognizes is `humidity_value` (the name category `tdq` happens to use), not the real dpcode this hub reports (`humidity_current`) — a dpcode name outside that recognized allowlist silently produces **no entity at all**, not even a disabled one. The `hwktwkq` spec entry works around this with an explicit `"shadow_code"` field: the value is still read from the device's real dpcode, but exposed to the rest of the pipeline under the recognized canonical name. Happy to fix this a different way (e.g. widening whatever list drives that recognition) if that's the better fix — flagging it here since it's the kind of thing likely to bite other categories too.

## Open design question for you

Right now this is an allowlist of known categories with a hand-written DP layout. An alternative would be a more generic "any category with empty status → try shadow/properties, keep whatever comes back" without hardcoding schema — simpler, but loses correct scale/unit/device_class for the created entities. Went with the explicit-schema version since it matches the existing `infrared_*` precedent in this same file, but genuinely open to your preferred shape here.

## Testing

Verified live against a real HA 2026.5.3 / Python 3.14.2 instance: both categories now expose real, correctly-scaled sensor entities (temperature/humidity/battery) with fresh timestamps, in addition to the events they already had. No regression observed on other devices (categories `kg`, `cz`, `infrared_ac`) across several reload/restart cycles.