### PR TITLE
climate: fall back to switch-only HVAC mode when no mode maps - Fix Cecotec BigDry 8000 Expert!

### DIFF
--- a/custom_components/xtend_tuya/climate.py
+++ b/custom_components/xtend_tuya/climate.py
@@ -646,6 +646,23 @@ class XTClimateEntity(XTEntity, TuyaClimateEntity):
                         if ha_mode_replace_heat_cool_with not in self._attr_hvac_modes:
                             self._attr_hvac_modes.append(ha_mode_replace_heat_cool_with)
 
+        # Some devices expose a mode DP whose options cannot be mapped to any
+        # HA HVACMode (they are surfaced as presets instead). For those, the
+        # loop above only produces [HVACMode.OFF] and the switch_wrapper branch
+        # is never reached, so switch_only_hvac_mode is lost: the entity ends up
+        # with a single mode and reports "unknown" because the parent cannot
+        # translate the raw mode value. Fall back to switch-only behaviour.
+        self._xt_switch_wrapper = definition.switch_wrapper
+        self._xt_switch_only_fallback = bool(
+            definition.switch_wrapper is not None
+            and not [m for m in self._attr_hvac_modes if m != HVACMode.OFF]
+        )
+        if self._xt_switch_only_fallback:
+            self._attr_hvac_modes = [
+                HVACMode.OFF,
+                description.switch_only_hvac_mode,
+            ]
+
     def get_configurable_properties_type(self) -> type[Any] | None:
         return XTClimateConfigurableProperties
 
@@ -762,6 +779,23 @@ class XTClimateEntity(XTEntity, TuyaClimateEntity):
         if ATTR_TEMPERATURE in kwargs and self.configurable_properties is not None and self.configurable_properties.target_temperature_value_multiplicator is not None:
             kwargs[ATTR_TEMPERATURE] = kwargs[ATTR_TEMPERATURE] / self.configurable_properties.target_temperature_value_multiplicator
         await super().async_set_temperature(**kwargs)
+
+    @property
+    def hvac_mode(self) -> HVACMode | None:  # type: ignore
+        """Return hvac mode.
+
+        When the device falls back to switch-only operation (see __init__),
+        the mode DP value is not translatable, so derive the mode from the
+        power switch instead of letting the parent return None.
+        """
+        if getattr(self, "_xt_switch_only_fallback", False):
+            value = self._read_wrapper(self._xt_switch_wrapper)
+            if value is None:
+                return None
+            if value:
+                return self.entity_description.switch_only_hvac_mode
+            return HVACMode.OFF
+        return super().hvac_mode
 
     @property
     def hvac_action(self) -> HVACAction | None:  # type: ignore


### PR DESCRIPTION
## Problem

A dehumidifier (Tuya category `cs`, "Big Dry 8000") shows `unknown` as its
climate state, and its more-info dialog offers **Off** as the only HVAC mode.
The device works otherwise: power, humidity, fan and presets are all fine.

## Root cause

In `XTClimateEntity.__init__`, the HVAC mode list is built as:

```python
if definition.hvac_mode_wrapper:
    self._attr_hvac_modes = [HVACMode.OFF]
    for tuya_mode in ...:
        if (ha_mode := MERGED_TUYALIB_TO_HA_HVACMODE_MAPPINGS.get(tuya_mode)) and ...:
            self._attr_hvac_modes.append(ha_mode)
elif definition.switch_wrapper:
    self._attr_hvac_modes = [HVACMode.OFF, description.switch_only_hvac_mode]
```

This device has **both** a mode DP and a power DP. Because `hvac_mode_wrapper`
is found, the first branch runs; none of the mode options map to an `HVACMode`
(they are exposed as presets, `1`, `2`, ...), so nothing is appended and the
list stays `[HVACMode.OFF]`. The `elif` that would have supplied
`switch_only_hvac_mode` (`HVACMode.DRY` for `cs`) is unreachable.

The same unmappable value makes the parent's `hvac_mode` return `None`, which
is what surfaces as `unknown`.

## Fix

After the mode and preset lists have been built, if a `switch_wrapper` exists
and no mode other than `OFF` was derived, fall back to switch-only behaviour:
add `switch_only_hvac_mode` to the list and derive `hvac_mode` from the power
switch.

The condition is deliberately generic rather than `category == "cs"` — it
describes exactly the situation `switch_only_hvac_mode` already exists for.
Devices that derive at least one usable mode are unaffected and keep the
parent's behaviour via `super().hvac_mode`.

No change is needed for setting the mode: the parent's `async_set_hvac_mode`
already sends `switch_wrapper -> (hvac_mode != HVACMode.OFF)`, and the mode
command is guarded by `hvac_mode in self._hvac_to_tuya`, so no bogus mode
write is emitted.

## Testing

Running on HA with the official Tuya integration installed alongside
(`custom_components/tuya` + `custom_components/xtend_tuya`):

- `hvac_modes` changed from `['off']` to `['off', 'dry']`
- state changed from `unknown` to `off` / `dry`
- selecting **Dry** turns the device on and the state survives a reload;
  selecting **Off** turns it off
- other climate devices on the same account are unchanged

## Note

`self._xt_switch_wrapper` duplicates the parent's `_switch_wrapper`. I kept a
local reference to avoid depending on a private attribute of the parent class,
but I'm happy to switch to `self._switch_wrapper` if you prefer.
